### PR TITLE
Only calculate sticky buttons and scrollbars after page renders

### DIFF
--- a/d2l-scroll-wrapper.html
+++ b/d2l-scroll-wrapper.html
@@ -349,9 +349,18 @@
 					showActions: Boolean
 				},
 
-				listeners: {
-					'iron-resize': 'checkScrollbar',
-					'wrapper.scroll': 'checkScrollThresholds'
+				attached: function() {
+					// Defer the offsetWidth/scrollWidth calculations until after the page has rendered
+					Polymer.RenderStatus.afterNextRender(this, function() {
+						this.listen(this, 'iron-resize', 'checkScrollbar');
+						this.listen(this.$.wrapper, 'scroll', 'checkScrollThresholds');
+						this.checkScrollbar();
+					}.bind(this));
+				},
+
+				detached: function() {
+					this.unlisten(this, 'iron-resize', 'checkScrollbar');
+					this.unlisten(this.$.wrapper, 'scroll', 'checkScrollThresholds');
 				},
 
 				_updateStyles: function() {

--- a/d2l-sticky-element.html
+++ b/d2l-sticky-element.html
@@ -49,7 +49,8 @@
 				Stickyfill.rebuild();
 			},
 			_disabledChanged: function() {
-				this.async(this._updateSticky);
+				// Defer the getComputedStyle() calls until after the page has rendered
+				Polymer.RenderStatus.afterNextRender(this, this._updateSticky.bind(this));
 			}
 		});
 	</script>

--- a/test/d2l-scroll-wrapper.html
+++ b/test/d2l-scroll-wrapper.html
@@ -87,9 +87,11 @@
 
 			describe('scrollbar', function() {
 				describe('ltr', function() {
-					beforeEach(function() {
+					beforeEach(function(done) {
 						this.scrollWrapper = fixture('with-scrollbar').querySelector('d2l-scroll-wrapper');
 						this.wrapper = this.scrollWrapper.$.wrapper;
+						Polymer.RenderStatus._flushNextRender();
+						flush(done);
 					});
 
 					common(false);
@@ -160,9 +162,11 @@
 				});
 
 				describe('rtl', function() {
-					beforeEach(function() {
+					beforeEach(function(done) {
 						this.scrollWrapper = fixture('with-scrollbar-rtl').querySelector('d2l-scroll-wrapper');
 						this.wrapper = this.scrollWrapper.$.wrapper;
+						Polymer.RenderStatus._flushNextRender();
+						flush(done);
 					});
 
 					describe('isRTL', function() {


### PR DESCRIPTION
In IE, the effect is very clear on some pages. The table gets rendered, then the border styling and sticky buttons show up. On Chrome, it's unnoticeable.