### PR TITLE
Optimize CSS

### DIFF
--- a/d2l-table-style.html
+++ b/d2l-table-style.html
@@ -5,50 +5,44 @@
 	<template>
 		<style>
 			:host {
-				--d2l-table-cell: {
-					border-top: var(--d2l-table-border);
-					border-right: var(--d2l-table-border);
-					display: table-cell;
-					padding: 1rem;
-					text-align: left;
-					vertical-align: middle;
-					font-weight: inherit;
+				--d2l-table-cell:{
+					border-top:var(--d2l-table-border);
+					border-right:var(--d2l-table-border);
+					display:table-cell;
+					text-align:left;
+					vertical-align:middle;
+					font-weight:inherit;
+					padding:1rem;
 				};
-
 				--d2l-table-header: {
-					color: var(--d2l-color-ferrite);
-					font-family: inherit;
-					font-size: 0.7rem;
-					font-weight: 400;
-					line-height: 1rem;
-					letter-spacing: 0.02rem;
-					margin: 1rem 0 1rem 0;
-					background-color: var(--d2l-table-header-background-color);
+					color:var(--d2l-color-ferrite);
+					font-family:inherit;
+					font-size:.7rem;
+					font-weight:400;
+					line-height:1rem;
+					letter-spacing:.02rem;
+					background-color:var(--d2l-table-header-background-color);
+					margin:1rem 0;
 				};
-
 				--d2l-table: {
-					background-color: transparent;
-					border-collapse: separate !important;
-					border-spacing: 0;
-					display: table;
-					width: 100%;
+					background-color:transparent;
+					border-collapse:separate!important;
+					border-spacing:0;
+					display:table;
+					width:100%;
 				};
-
 				--d2l-table-head: {
-					display: table-header-group;
+					display:table-header-group;
 				};
-
 				--d2l-table-foot: {
-					display: table-footer-group;
-					background-color: var(--d2l-table-body-background-color);
+					display:table-footer-group;
+					background-color:var(--d2l-table-body-background-color);
 				};
-
 				--d2l-table-body: {
-					background-color: var(--d2l-table-body-background-color);
+					background-color:var(--d2l-table-body-background-color);
 				};
-
 				--d2l-table-row: {
-					display: table-row;
+					display:table-row;
 				};
 			}
 
@@ -86,7 +80,7 @@
 			:host-context([dir="rtl"]) > ::content > tr > td,
 			:host-context([dir="rtl"]) > ::content > tbody > tr > th,
 			:host-context([dir="rtl"]) > ::content > tfoot > tr > th {
-				text-align: right;
+				text-align:right;
 			}
 
 			:host > ::content > thead > tr > th,
@@ -94,52 +88,61 @@
 				@apply(--d2l-table-header);
 			}
 
-			:host-context([dir="rtl"]) > ::content > * > tr >:first-child,
-			:host-context([dir="rtl"]) > ::content > tr >:first-child {
-				border-left: 0;
+			:host-context([dir="rtl"]) > ::content > * > tr  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > * > tr  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tr  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tr  > th:first-child {
+				border-left:0;
 			}
 
-			:host-context([dir="rtl"]) > ::content > * > tr >:last-child,
-			:host-context([dir="rtl"]) > ::content > tr >:last-child,
-			:host > ::content > * > tr >:first-child,
-			:host > ::content > tr >:first-child {
-				border-left: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]) > ::content > * > tr  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > * > tr  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tr  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tr  > th:last-child {
+				border-right:var(--d2l-table-border);
 			}
 
-			:host-context([dir="rtl"]) > ::content > * > tr >:last-child,
-			:host-context([dir="rtl"]) > ::content > tr >:last-child {
-				border-right: var(--d2l-table-border);
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > th:first-child {
+				border-top-left-radius:0;
+				border-top-right-radius:var(--d2l-table-border-radius);
 			}
 
-			:host-context([dir="rtl"]) > ::content > * > tr >:first-child,
-			:host-context([dir="rtl"]) > ::content > tr >:first-child,
-			:host > ::content > * > tr >:last-child,
-			:host > ::content > tr >:last-child {
-				border-right: var(--d2l-table-outer-border);
-			}
-
-			:host-context([dir="rtl"]) > ::content > thead > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child >:first-child {
-				border-top-left-radius: 0;
-				border-top-right-radius: var(--d2l-table-border-radius);
-			}
-			:host > ::content > thead > tr:first-child >:last-child,
-			:host > ::content > tbody:only-child > tr:first-child >:last-child,
-			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > caption:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child >:last-child {
-				border-top-right-radius: var(--d2l-table-border-radius);
+			:host > ::content > thead > tr:first-child  > td:last-child,
+			:host > ::content > thead > tr:first-child  > th:last-child,
+			:host > ::content > tbody:only-child > tr:first-child  > td:last-child,
+			:host > ::content > tbody:only-child > tr:first-child  > th:last-child,
+			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > caption:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > caption:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > th:last-child {
+				border-top-right-radius:var(--d2l-table-border-radius);
 			}
 
 			:host > ::content > thead > tr:first-child > th,
@@ -159,45 +162,73 @@
 			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child > td,
 			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child > td,
 			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child > td {
-				border-top: var(--d2l-table-outer-border);
+				border-top:var(--d2l-table-outer-border);
 			}
 
-			:host-context([dir="rtl"]) > ::content > thead > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child >:last-child {
-				border-top-right-radius: 0;
-				border-top-left-radius: var(--d2l-table-border-radius);
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > th:last-child {
+				border-top-right-radius:0;
+				border-top-left-radius:var(--d2l-table-border-radius);
 			}
-			:host > ::content > thead > tr:first-child >:first-child,
-			:host > ::content > tbody:only-child > tr:first-child >:first-child,
-			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > caption:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child >:first-child,
-			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child >:first-child {
-				border-top-left-radius: var(--d2l-table-border-radius);
+
+			:host > ::content > thead > tr:first-child  > td:first-child,
+			:host > ::content > thead > tr:first-child  > th:first-child,
+			:host > ::content > tbody:only-child > tr:first-child  > td:first-child,
+			:host > ::content > tbody:only-child > tr:first-child  > th:first-child,
+			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > caption:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > caption:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > th:first-child,
+			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > td:first-child,
+			:host > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > th:first-child {
+				border-top-left-radius:var(--d2l-table-border-radius);
 			}
 
 			/* This is needed for the rtl case when the there is only one td/th in a row. Doesn't affect all browsers */
-			:host-context([dir="rtl"]) > ::content > thead > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child >:only-child {
-				border-top-right-radius: var(--d2l-table-border-radius);
-				border-top-left-radius: var(--d2l-table-border-radius);
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > thead > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > tfoot:first-child + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + tfoot + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > caption:first-child + colgroup + tfoot + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tbody:last-child > tr:first-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup:first-child + tfoot + tbody:last-child > tr:first-child  > th:only-child {
+				border-top-right-radius:var(--d2l-table-border-radius);
+				border-top-left-radius:var(--d2l-table-border-radius);
 			}
 
 			:host > ::content > thead:only-child > tr:last-child > th,
@@ -213,27 +244,42 @@
 			:host > ::content > colgroup + tbody:last-child > tr:last-child > td,
 			:host > ::content > tbody:last-child > tr:last-child > td,
 			:host > ::content > tbody:last-child > tr:last-child > th {
-				border-bottom: var(--d2l-table-border);
+				border-bottom:var(--d2l-table-border);
 			}
 
-			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child >:first-child,
-			:host-context([dir="rtl"]) > ::content > * > tr[last-row] >:first-child {
-				border-bottom-left-radius: 0;
-				border-bottom-right-radius: var(--d2l-table-border-radius);
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > th:first-child {
+				border-bottom-left-radius:0;
+				border-bottom-right-radius:var(--d2l-table-border-radius);
 			}
-			:host > ::content > thead:only-child > tr:last-child >:last-child,
-			:host > ::content > tfoot > tr:last-child >:last-child,
-			:host > ::content > tbody:only-child > tr:last-child >:last-child,
-			:host > ::content > thead + tbody:last-child > tr:last-child >:last-child,
-			:host > ::content > caption + tbody:last-child > tr:last-child >:last-child,
-			:host > ::content > colgroup + tbody:last-child > tr:last-child >:last-child,
-			:host > ::content > * > tr[last-row] >:last-child {
-				border-bottom-right-radius: var(--d2l-table-border-radius);
+
+			:host > ::content > thead:only-child > tr:last-child  > td:last-child,
+			:host > ::content > thead:only-child > tr:last-child  > th:last-child,
+			:host > ::content > tfoot > tr:last-child  > td:last-child,
+			:host > ::content > tfoot > tr:last-child  > th:last-child,
+			:host > ::content > tbody:only-child > tr:last-child  > td:last-child,
+			:host > ::content > tbody:only-child > tr:last-child  > th:last-child,
+			:host > ::content > thead + tbody:last-child > tr:last-child  > td:last-child,
+			:host > ::content > thead + tbody:last-child > tr:last-child  > th:last-child,
+			:host > ::content > caption + tbody:last-child > tr:last-child  > td:last-child,
+			:host > ::content > caption + tbody:last-child > tr:last-child  > th:last-child,
+			:host > ::content > colgroup + tbody:last-child > tr:last-child  > td:last-child,
+			:host > ::content > colgroup + tbody:last-child > tr:last-child  > th:last-child,
+			:host > ::content > * > tr[last-row]  > td:last-child,
+			:host > ::content > * > tr[last-row]  > th:last-child {
+				border-bottom-right-radius:var(--d2l-table-border-radius);
 			}
 
 			:host > ::content > thead:only-child > tr:last-child > th,
@@ -249,120 +295,125 @@
 			:host > ::content > colgroup + tbody:last-child > tr:last-child > td,
 			:host > ::content > * > tr[last-row] > th,
 			:host > ::content > * > tr[last-row] > td {
-				border-bottom: var(--d2l-table-outer-border);
+				border-bottom:var(--d2l-table-outer-border);
 			}
 
-			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child >:last-child,
-			:host-context([dir="rtl"]) > ::content > * > tr[last-row] > th:last-child,
-			:host-context([dir="rtl"]) > ::content > * > tr[last-row] > td:last-child {
-				border-bottom-right-radius: 0;
-				border-bottom-left-radius: var(--d2l-table-border-radius);
-			}
-			:host > ::content > thead:only-child > tr:last-child >:first-child,
-			:host > ::content > tfoot > tr:last-child >:first-child,
-			:host > ::content > tbody:only-child > tr:last-child >:first-child,
-			:host > ::content > thead + tbody:last-child > tr:last-child >:first-child,
-			:host > ::content > caption + tbody:last-child > tr:last-child >:first-child,
-			:host > ::content > colgroup + tbody:last-child > tr:last-child >:first-child,
-			:host > ::content > * > tr[last-row] > th:first-child,
-			:host > ::content > * > tr[last-row] > td:first-child {
-				border-bottom-left-radius: var(--d2l-table-border-radius);
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > th:last-child {
+				border-bottom-right-radius:0;
+				border-bottom-left-radius:var(--d2l-table-border-radius);
 			}
 
-			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child >:only-child,
-			:host-context([dir="rtl"]) > ::content > * > tr[last-row] > th:only-child,
-			:host-context([dir="rtl"]) > ::content > * > tr[last-row] > td:only-child {
-				border-bottom-left-radius: var(--d2l-table-border-radius);
-				border-bottom-right-radius: var(--d2l-table-border-radius);
+			:host > ::content > thead:only-child > tr:last-child  > td:first-child,
+			:host > ::content > thead:only-child > tr:last-child  > th:first-child,
+			:host > ::content > tfoot > tr:last-child  > td:first-child,
+			:host > ::content > tfoot > tr:last-child  > th:first-child,
+			:host > ::content > tbody:only-child > tr:last-child  > td:first-child,
+			:host > ::content > tbody:only-child > tr:last-child  > th:first-child,
+			:host > ::content > thead + tbody:last-child > tr:last-child  > td:first-child,
+			:host > ::content > thead + tbody:last-child > tr:last-child  > th:first-child,
+			:host > ::content > caption + tbody:last-child > tr:last-child  > td:first-child,
+			:host > ::content > caption + tbody:last-child > tr:last-child  > th:first-child,
+			:host > ::content > colgroup + tbody:last-child > tr:last-child  > td:first-child,
+			:host > ::content > colgroup + tbody:last-child > tr:last-child  > th:first-child,
+			:host > ::content > * > tr[last-row]  > td:first-child,
+			:host > ::content > * > tr[last-row]  > th:first-child {
+				border-bottom-left-radius:var(--d2l-table-border-radius);
+			}
+
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > thead:only-child > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > tfoot > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > tbody:only-child > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > thead + tbody:last-child > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > caption + tbody:last-child > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > colgroup + tbody:last-child > tr:last-child  > th:only-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > td:only-child,
+			:host-context([dir="rtl"]) > ::content > * > tr[last-row]  > th:only-child {
+				border-bottom-left-radius:var(--d2l-table-border-radius);
+				border-bottom-right-radius:var(--d2l-table-border-radius);
 			}
 
 			:host > ::content > tfoot > tr:first-child> td,
 			:host > ::content > tfoot > tr:first-child> th {
-				border-top: none;
+				border-top:none;
 			}
 
 			:host > ::content > tbody > tr[active],
 			:host([selectable]) > ::content > tbody > tr:not([selected]):hover {
-				background-color: var(--d2l-table-row-background-color-active);
+				background-color:var(--d2l-table-row-background-color-active);
 			}
 
 			:host > ::content > tbody > tr[selected] {
-				background-color: var(--d2l-table-row-background-color-selected);
+				background-color:var(--d2l-table-row-background-color-selected);
 			}
 
-			:host-context([dir="rtl"]) > ::content > tbody > tr[selected] >:first-child {
-				border-left-color: var(--d2l-table-border-color);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > th:first-child,
+			:host > ::content > tbody > tr[selected]  > td:last-child,
+			:host > ::content > tbody > tr[selected]  > th:last-child {
+				border-right-color:var(--d2l-table-outer-row-border-color-selected);
 			}
 
-			:host-context([dir="rtl"]) > ::content > tbody > tr[selected] >:first-child,
-			:host > ::content > tbody > tr[selected] >:last-child {
-				border-right-color: var(--d2l-table-outer-row-border-color-selected);
-			}
-
-			:host-context([dir="rtl"]) > ::content > tbody > tr[selected] >:last-child {
-				border-right-color: var(--d2l-table-border-color);
-			}
-
-			:host-context([dir="rtl"]) > ::content > tbody > tr[selected] >:last-child,
-			:host > ::content > tbody > tr[selected] >:first-child {
-				border-left-color: var(--d2l-table-outer-row-border-color-selected);
-			}
-
-			:host > ::content > tbody > tr[selected] > td,
-			:host > ::content > tbody > tr[selected] > th {
-				border-top-color: var(--d2l-table-row-border-color-selected);
-			}
-
-			:host > ::content > tbody > tr[selected] + tr > td,
-			:host > ::content > tbody > tr[selected] + tr > th {
-				border-top-color: var(--d2l-table-row-border-color-selected);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > th:last-child,
+			:host > ::content > tbody > tr[selected]  > td:first-child,
+			:host > ::content > tbody > tr[selected]  > th:first-child {
+				border-left-color:var(--d2l-table-outer-row-border-color-selected);
 			}
 
 			:host > ::content > tbody > tr[active][selected],
 			:host([selectable]) > ::content > tbody > tr[selected]:hover {
-				background-color: var(--d2l-table-row-background-color-active-selected);
+				background-color:var(--d2l-table-row-background-color-active-selected);
 			}
 
-			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected] >:first-child,
-			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover >:first-child {
-				border-left-color: var(--d2l-table-border-color);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > th:first-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > td:first-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > th:first-child,
+			:host > ::content > tbody > tr[active][selected]  > td:last-child,
+			:host > ::content > tbody > tr[active][selected]  > th:last-child,
+			:host([selectable]) > ::content > tbody > tr[selected]:hover  > td:last-child,
+			:host([selectable]) > ::content > tbody > tr[selected]:hover  > th:last-child {
+				border-right-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
-			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected] >:first-child,
-			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover >:first-child,
-			:host > ::content > tbody > tr[active][selected] >:last-child,
-			:host([selectable]) > ::content > tbody > tr[selected]:hover >:last-child {
-				border-right-color: var(--d2l-table-outer-row-border-color-active-selected);
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > td:first-child,
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > th:first-child {
+				border-right-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
-			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover >:first-child {
-				border-left-color: var(--d2l-table-border-color);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > th:last-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > td:last-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > th:last-child,
+			:host > ::content > tbody > tr[active][selected]  > td:first-child,
+			:host > ::content > tbody > tr[active][selected]  > th:first-child,
+			:host([selectable]) > ::content > tbody > tr[selected]:hover  > td:first-child,
+			:host([selectable]) > ::content > tbody > tr[selected]:hover  > th:first-child {
+				border-left-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
-			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected] >:last-child,
-			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover >:last-child {
-				border-right-color: var(--d2l-table-border-color);
-			}
-
-			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected] >:last-child,
-			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover >:last-child,
-			:host > ::content > tbody > tr[active][selected] >:first-child,
-			:host([selectable]) > ::content > tbody > tr[selected]:hover >:first-child {
-				border-left-color: var(--d2l-table-outer-row-border-color-active-selected);
-			}
-
-			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover >:last-child {
-				border-right-color: var(--d2l-table-border-color);
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > td:last-child,
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > th:last-child {
+				border-left-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
 			:host > ::content > tbody > tr[active][selected] > td,
@@ -373,26 +424,26 @@
 			:host > ::content > tbody > tr[active][selected] + tr > th,
 			:host([selectable]) > ::content > tbody > tr[selected]:hover + tr > td,
 			:host([selectable]) > ::content > tbody > tr[selected]:hover + tr > th {
-				border-top-color: var(--d2l-table-row-border-color-active-selected);
+				border-top-color:var(--d2l-table-row-border-color-active-selected);
 			}
 
 			:host > ::content > tbody > tr:first-child[selected] > td,
 			:host > ::content > tbody > tr:first-child[selected] > th {
-				border-top-color: var(--d2l-table-outer-row-border-color-selected);
+				border-top-color:var(--d2l-table-outer-row-border-color-selected);
 			}
 
 			:host > ::content > tbody > tr:first-child[active][selected] > td,
 			:host > ::content > tbody > tr:first-child[active][selected] > th,
 			:host([selectable]) > ::content > tbody > tr:first-child[selected]:hover > td,
 			:host([selectable]) > ::content > tbody > tr:first-child[selected]:hover > th {
-				border-top-color: var(--d2l-table-outer-row-border-color-active-selected);
+				border-top-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
 			:host > ::content > tbody > tr:last-child[selected] > td,
 			:host > ::content > tbody > tr:last-child[selected] > th,
 			:host > ::content > tbody > tr[last-row][selected] > td,
 			:host > ::content > tbody > tr[last-row][selected] > th {
-				border-bottom-color: var(--d2l-table-outer-row-border-color-selected);
+				border-bottom-color:var(--d2l-table-outer-row-border-color-selected);
 			}
 
 			:host > ::content > tbody > tr:last-child[active][selected] > td,
@@ -403,59 +454,110 @@
 			:host > ::content > tbody > tr[last-row][active][selected] > th,
 			:host([selectable]) > ::content > tbody > tr[last-row][selected]:hover > td,
 			:host([selectable]) > ::content > tbody > tr[last-row][selected]:hover > th {
-				border-bottom-color: var(--d2l-table-outer-row-border-color-active-selected);
+				border-bottom-color:var(--d2l-table-outer-row-border-color-active-selected);
 			}
 
 			:host([no-column-border]) > ::content > tbody > tr > td,
 			:host([no-column-border]) > ::content > tbody > tr > th {
-				border-left: none;
-				border-right: none;
+				border-left:none;
+				border-right:none;
 			}
 
-			:host([no-column-border]) > ::content > tbody > tr > td:first-child,
-			:host([no-column-border]) > ::content > tbody > tr > th:first-child {
-				border-left: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]) > ::content > * > tr  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > * > tr  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tr  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tr  > th:last-child,
+			:host > ::content > * > tr  > td:first-child,
+			:host > ::content > * > tr  > th:first-child,
+			:host > ::content > tr  > td:first-child,
+			:host > ::content > tr  > th:first-child,
+			:host([no-column-border]) > ::content > tbody > tr  > td:first-child,
+			:host([no-column-border]) > ::content > tbody > tr  > th:first-child {
+				border-left:var(--d2l-table-outer-border);
 			}
 
-			:host([no-column-border]) > ::content > tbody > tr > td:last-child,
-			:host([no-column-border]) > ::content > tbody > tr > th:last-child {
-				border-right: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]) > ::content > * > tr  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > * > tr  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tr  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tr  > th:first-child,
+			:host > ::content > * > tr  > td:last-child,
+			:host > ::content > * > tr  > th:last-child,
+			:host > ::content > tr  > td:last-child,
+			:host > ::content > tr  > th:last-child,
+			:host([no-column-border]) > ::content > tbody > tr  > td:last-child,
+			:host([no-column-border]) > ::content > tbody > tr  > th:last-child {
+				border-right:var(--d2l-table-outer-border);
 			}
 
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > td:first-child,
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > th:first-child {
-				border-left: none;
-				border-right: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > th:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > td:first-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > th:first-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > td:first-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > th:first-child {
+				border-left-color:var(--d2l-table-border-color);
 			}
 
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > td:first-child,
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > th:first-child {
-				border-left: none;
-				border-right: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > td:first-child,
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > th:first-child {
+				border-left-color:var(--d2l-table-border-color);
 			}
 
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > td:last-child,
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > th:last-child {
-				border-right: none;
-				border-left: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[selected]  > th:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > td:last-child,
+			:host-context([dir="rtl"]) > ::content > tbody > tr[active][selected]  > th:last-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > td:last-child,
+			:host-context([dir="rtl"])[selectable] > ::content > tbody > tr[selected]:hover  > th:last-child {
+				border-right-color:var(--d2l-table-border-color);
 			}
 
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > td:last-child,
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > th:last-child {
-				border-right: none;
-				border-left: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > td:last-child,
+			:host-context([dir="rtl"]):host([selectable]) > ::content > tbody > tr[selected]:hover  > th:last-child {
+				border-right-color:var(--d2l-table-border-color);
 			}
 
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > td:only-child,
-			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr > th:only-child {
-				border-right: var(--d2l-table-outer-border);
-				border-left: var(--d2l-table-outer-border);
+			:host > ::content > tbody > tr[selected] > td,
+			:host > ::content > tbody > tr[selected] > th,
+			:host > ::content > tbody > tr[selected] + tr > td,
+			:host > ::content > tbody > tr[selected] + tr > th {
+				border-top-color:var(--d2l-table-row-border-color-selected);
 			}
 
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > td:only-child,
-			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr > th:only-child {
-				border-right: var(--d2l-table-outer-border);
-				border-left: var(--d2l-table-outer-border);
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > td:first-child,
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > th:first-child {
+				border-left:none;
+				border-right:var(--d2l-table-outer-border);
+			}
+
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > td:first-child,
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > th:first-child {
+				border-left:none;
+				border-right:var(--d2l-table-outer-border);
+			}
+
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > td:last-child,
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > th:last-child {
+				border-right:none;
+				border-left:var(--d2l-table-outer-border);
+			}
+
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > td:last-child,
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > th:last-child {
+				border-right:none;
+				border-left:var(--d2l-table-outer-border);
+			}
+
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > td:only-child,
+			:host-context([dir="rtl"])[no-column-border] > ::content > tbody > tr  > th:only-child {
+				border-right:var(--d2l-table-outer-border);
+				border-left:var(--d2l-table-outer-border);
+			}
+
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > td:only-child,
+			:host-context([dir="rtl"]):host([no-column-border]) > ::content > tbody > tr  > th:only-child {
+				border-right:var(--d2l-table-outer-border);
+				border-left:var(--d2l-table-outer-border);
 			}
 		</style>
 	</template>

--- a/demo/simple.html
+++ b/demo/simple.html
@@ -13,6 +13,7 @@
 
 			body {
 				margin: 0;
+				overflow-x: hidden;
 			}
 
 			:root {


### PR DESCRIPTION
* Collect similar rules, remove >:first-child, >:last-child, >:only-child rules
* 29% gains in IE11 when styles are being calculated. On the enter grades page, this is ~67ms faster for every style calc. Less CPU => happier browser => happier user