### PR TITLE
Use stickyfill 1.1.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "d2l-colors": "^2.2.3",
     "d2l-icons": "^3.1.1",
     "iron-resizable-behavior": "^1.0.5",
-    "Stickyfill": "seaneking/stickyfill#master"
+    "Stickyfill": "1.1.4"
   },
   "devDependencies": {
     "d2l-demo-template": "^0.0.12",


### PR DESCRIPTION
* This version doesn't work with Shadow DOM, but Chrome has position:sticky implemented

Fixes #115 