### PR TITLE
fix inner table inheriting sticky styling

### DIFF
--- a/d2l-table-style.html
+++ b/d2l-table-style.html
@@ -286,6 +286,7 @@
 				position: sticky;
 				top: -5px;
 				border-left: none;
+				border-top: none;
 				border-bottom: var(--d2l-table-border);
 			}
 

--- a/d2l-table-style.html
+++ b/d2l-table-style.html
@@ -371,7 +371,7 @@
 			}
 
 			[dir="rtl"] [sticky-headers] .d2l-table [selected] .d2l-table-cell-first,
-			[dir="rtl"] [sticky-headers] .d2l-table [selected] > thead > tr > td:first-child {
+			[dir="rtl"] [sticky-headers] .d2l-table [selected] > thead > tr > td:first-child,
 			[dir="rtl"] [sticky-headers] .d2l-table [selected] > tbody > tr > td:first-child {
 				border-left: var(--d2l-table-border);
 			}

--- a/d2l-table-style.html
+++ b/d2l-table-style.html
@@ -286,7 +286,6 @@
 				position: sticky;
 				top: -5px;
 				border-left: none;
-				border-top: none;
 				border-bottom: var(--d2l-table-border);
 			}
 
@@ -309,10 +308,10 @@
 			[sticky-headers] tbody tr:not([header]):not([selected]):first-child td,
 			[sticky-headers] tbody tr:not([header]):not([selected]):first-child th  {
 				border-top: none;
-				border-bottom: none;
 			}
 
-			[sticky-headers] tr[header] + tr:not([header])[selected] td,
+			[sticky-headers] .d2l-table > thead > tr[header] + tr:not([header])[selected] > td,
+			[sticky-headers] .d2l-table > tbody > tr[header] + tr:not([header])[selected] > td,
 			[sticky-headers] tr[header] + tr:not([header])[selected] th
 			[sticky-headers] tbody tr[selected]:first-child td,
 			[sticky-headers] tbody tr[selected]:first-child th {
@@ -344,14 +343,16 @@
 				background-color: inherit;
 			}
 
-			[dir="rtl"] [sticky-headers] .d2l-table td,
+			[dir="rtl"] [sticky-headers] .d2l-table > thead > tr > td,
+			[dir="rtl"] [sticky-headers] .d2l-table > tbody > tr > td,
 			[dir="rtl"] [sticky-headers] .d2l-table th {
 				border-left: var(--d2l-table-border);
 				border-right: none;
 			}
 
 			[dir="rtl"] [sticky-headers] .d2l-table [selected] .d2l-table-cell-last,
-			[dir="rtl"] [sticky-headers] .d2l-table tbody tr[selected] td:last-child {
+			[dir="rtl"] [sticky-headers] .d2l-table > thead > tr[selected] > td:last-child,
+			[dir="rtl"] [sticky-headers] .d2l-table > tbody > tr[selected] > td:last-child {
 				border-left: var(--d2l-table-border);
 				border-left-color: var(--d2l-table-row-border-color-selected);
 			}
@@ -363,13 +364,15 @@
 			}
 
 			[dir="rtl"] [sticky-headers] .d2l-table .d2l-table-cell-first,
-			[dir="rtl"] [sticky-headers] .d2l-table td:first-child,
+			[dir="rtl"] [sticky-headers] .d2l-table > thead > tr > td:first-child,
+			[dir="rtl"] [sticky-headers] .d2l-table > tbody > tr > td:first-child,
 			[dir="rtl"] [sticky-headers] .d2l-table th:first-child {
 				border-right: var(--d2l-table-border);
 			}
 
 			[dir="rtl"] [sticky-headers] .d2l-table [selected] .d2l-table-cell-first,
-			[dir="rtl"] [sticky-headers] .d2l-table [selected] td:first-child {
+			[dir="rtl"] [sticky-headers] .d2l-table [selected] > thead > tr > td:first-child {
+			[dir="rtl"] [sticky-headers] .d2l-table [selected] > tbody > tr > td:first-child {
 				border-left: var(--d2l-table-border);
 			}
 

--- a/demo/sticky-headers.html
+++ b/demo/sticky-headers.html
@@ -420,7 +420,19 @@
 								<th>Column header 20</th>
 							</tr>
 							<tr selected>
-								<td sticky>Row 1 Column 1</td>
+								<td sticky>Row 1 Column 1
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 								<td>Row 1 Column 2</td>
 								<td>Row 1 Column 3 - Also really really really long</td>
 								<td>Row 1 Column 4</td>
@@ -432,17 +444,53 @@
 								<td>Row 1 Column 10</td>
 								<td>Row 1 Column 11</td>
 								<td>Row 1 Column 12</td>
-								<td>Row 1 Column 13</td>
+								<td>Row 1 Column 13
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 								<td>Row 1 Column 14</td>
 								<td>Row 1 Column 15</td>
 								<td>Row 1 Column 16</td>
 								<td>Row 1 Column 17</td>
 								<td>Row 1 Column 18</td>
 								<td>Row 1 Column 19</td>
-								<td>Row 1 Column 20</td>
+								<td>Row 1 Column 20
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 							</tr>
 							<tr>
-								<td sticky>Row 2 Column 1</td>
+								<td sticky>Row 2 Column 1
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 								<td>Row 2 Column 2</td>
 								<td>Row 2 Column 3</td>
 								<td>Row 2 Column 4</td>
@@ -454,14 +502,38 @@
 								<td>Row 2 Column 10</td>
 								<td>Row 2 Column 11</td>
 								<td>Row 2 Column 12</td>
-								<td>Row 2 Column 13</td>
+								<td>Row 2 Column 13
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 								<td>Row 2 Column 14</td>
 								<td>Row 2 Column 15</td>
 								<td>Row 2 Column 16</td>
 								<td>Row 2 Column 17</td>
 								<td>Row 2 Column 18</td>
 								<td>Row 2 Column 19</td>
-								<td>Row 2 Column 20</td>
+								<td>Row 2 Column 20
+									<table>
+										<tbody>
+											<tr>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td> / </td>
+												<td><input style="width:100%;min-width:1rem;max-width:5.25rem;"/></td>
+												<td><d2l-icon icon="d2l-tier1:chevron-right" style="width:18px;height:18px;"></td>
+												<td><d2l-icon icon="d2l-tier1:calculate" style="width:18px;height:18px;"></td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
 							</tr>
 							<tr selected>
 								<td sticky>Row 3 Column 1</td>


### PR DESCRIPTION
Three fixes in this PR:

1. inner tables were inheriting styling rules from the sticky table. I modified just the rules that were causing problems on the grade_final_edit page. Some (but not all) of the rules were RTL only.
2. Jared's one-line fix
3. If a sticky header has two rows, the horizontal border between them disappears when the header is stuck. I fixed that by removing a `border-top: none`.