### PR TITLE
DE29930 - Add type=button for column sort and scroll buttons

### DIFF
--- a/d2l-scroll-wrapper.html
+++ b/d2l-scroll-wrapper.html
@@ -221,6 +221,7 @@
 				on-tap="handleTapLeft"
 				tabindex="-1"
 				aria-hidden="true"
+				type="button"
 			></d2l-icon-button>
 			<d2l-icon-button
 				class="right action"
@@ -228,6 +229,7 @@
 				on-tap="handleTapRight"
 				tabindex="-1"
 				aria-hidden="true"
+				type="button"
 			></d2l-icon-button>
 		</d2l-sticky-element>
 		<div id="wrapper" class="wrapper">

--- a/d2l-table-col-sort-button.html
+++ b/d2l-table-col-sort-button.html
@@ -43,7 +43,7 @@
 				display: none;
 			}
 		</style>
-		<button>
+		<button type="button">
 			<slot></slot>
 			<d2l-table-col-sort hidden="[[nosort]]" desc="[[desc]]"></d2l-table-col-sort>
 		</button>


### PR DESCRIPTION
type=button required so that these buttons don't attempt to submit forms
from legacy pages before the page has loaded.