### PR TITLE
added checkScrollDeltaValue attribute

### DIFF
--- a/d2l-scroll-wrapper.html
+++ b/d2l-scroll-wrapper.html
@@ -364,6 +364,12 @@
 						reflectToAttribute: true
 					},
 					/** IE and Edge requires the value to be 1 in some cases **/
+					/**
+						Background: In some occasions in IE and Edge, there is a
+						little deviation in the lowerScrollValue used in checkScrollThresholds for not being 0.
+						I have seen it being 1 in IE and Edge. Resulting the scroll arrow icon being shown
+						incorrectly when there is no overflow happening in UI.
+					**/
 					checkScrollDeltaValue: {
 						type: Number,
 						value: 0
@@ -478,8 +484,9 @@
 				},
 
 				checkScrollbar: function() {
-					var hScrollbar = this.$.wrapper.offsetWidth !== this.$.wrapper.scrollWidth;
-					this._setHScrollbar(hScrollbar);
+					var hScrollbar = Math.abs(this.$.wrapper.offsetWidth - this.$.wrapper.scrollWidth);
+
+					this._setHScrollbar(hScrollbar > 0 && hScrollbar !== this.checkScrollDeltaValue) ;
 					this.checkScrollThresholds();
 				},
 

--- a/d2l-scroll-wrapper.html
+++ b/d2l-scroll-wrapper.html
@@ -363,7 +363,11 @@
 						type: Boolean,
 						reflectToAttribute: true
 					},
-
+					/** IE and Edge requires the value to be 1 in some cases **/
+					checkScrollDeltaValue: {
+						type: Number,
+						value: 0
+					},
 					_stickyIsDisabled: {
 						type: Boolean,
 						computed: '_computeStickyIsDisabled(scrollbarLeft, scrollbarRight)'
@@ -484,10 +488,10 @@
 
 					if (this.isRtl && this.scrollRtlDefault) {
 						this._setScrollbarRight(this.$.wrapper.scrollLeft === 0);
-						this._setScrollbarLeft(lowerScrollValue <= 0);
+						this._setScrollbarLeft(lowerScrollValue <= this.checkScrollDeltaValue);
 					} else {
 						this._setScrollbarLeft(this.$.wrapper.scrollLeft === 0);
-						this._setScrollbarRight(lowerScrollValue <= 0);
+						this._setScrollbarRight(lowerScrollValue <= this.checkScrollDeltaValue);
 					}
 				},
 


### PR DESCRIPTION
In some occasions in IE and Edge, there is a little deviation in the lowerScrollValue used in checkScrollThresholds for not being 0. I have seen it being 1 in IE and Edge. Resulting the scroll arrow icon being shown incorrectly when there is no overflow happening in UI. 

I am making the check value to be an attribute defaulting to zero, so people with problems can make their own fine tuning adjustment.