### PR TITLE
DE32893 -- Workaround broken ResizeObserver in Polymer 3

### DIFF
--- a/d2l-tspan-resize-observer-polyfill.js
+++ b/d2l-tspan-resize-observer-polyfill.js
@@ -1,0 +1,42 @@
+if( window.ResizeObserver === undefined ) {
+	// The more efficient ResizeObserver pollyfills don't work with Polymer 3
+	// due to shadow DOM complications. Fallback to this method instead.
+	
+	window.ResizeObserver = function( callback ) {
+		this._callback = callback;
+		this._trackedNodes = [];
+		
+		this._checkForChanges = function() {
+			this._trackedNodes.forEach( function( trackedNode ) {
+				if(
+					trackedNode.ref.offsetWidth !== trackedNode.lastWidth ||
+					trackedNode.ref.offsetHeight !== trackedNode.lastHeight
+				) {
+					trackedNode.lastWidth = trackedNode.ref.offsetWidth;
+					trackedNode.lastHeight = trackedNode.ref.offsetHeight;
+					this._callback( trackedNode.ref );
+				}
+			}.bind( this ));
+			window.requestAnimationFrame( this._checkForChanges.bind( this ) );
+		}.bind( this );
+		this._checkForChanges();
+	};
+	
+	ResizeObserver.prototype.observe = function( node ) {
+		this._trackedNodes.push({
+			ref: node,
+			lastWidth: node.offsetWidth,
+			lastHeight: node.offsetHeight
+		});
+		this._callback( node );
+	};
+	
+	ResizeObserver.prototype.unobserve = function( node ) {
+		for( var i = 0; i < this._trackedNodes.length; i++ ) {
+			if( this._trackedNodes[i].ref === node ) {
+				this._trackedNodes.splice( i, 1 );
+				break;
+			}
+		}
+	};
+}

--- a/d2l-tspan-resize-observer-polyfill.js
+++ b/d2l-tspan-resize-observer-polyfill.js
@@ -1,40 +1,40 @@
-if( window.ResizeObserver === undefined ) {
+if (window.ResizeObserver === undefined) {
 	// The more efficient ResizeObserver pollyfills don't work with Polymer 3
 	// due to shadow DOM complications. Fallback to this method instead.
-	
-	window.ResizeObserver = function( callback ) {
+
+	window.ResizeObserver = function(callback) {
 		this._callback = callback;
 		this._trackedNodes = [];
-		
+
 		this._checkForChanges = function() {
-			this._trackedNodes.forEach( function( trackedNode ) {
-				if(
+			this._trackedNodes.forEach(function(trackedNode) {
+				if (
 					trackedNode.ref.offsetWidth !== trackedNode.lastWidth ||
 					trackedNode.ref.offsetHeight !== trackedNode.lastHeight
 				) {
 					trackedNode.lastWidth = trackedNode.ref.offsetWidth;
 					trackedNode.lastHeight = trackedNode.ref.offsetHeight;
-					this._callback( trackedNode.ref );
+					this._callback(trackedNode.ref);
 				}
-			}.bind( this ));
-			window.requestAnimationFrame( this._checkForChanges.bind( this ) );
-		}.bind( this );
+			}.bind(this));
+			window.requestAnimationFrame(this._checkForChanges.bind(this));
+		}.bind(this);
 		this._checkForChanges();
 	};
-	
-	ResizeObserver.prototype.observe = function( node ) {
+
+	ResizeObserver.prototype.observe = function(node) {
 		this._trackedNodes.push({
 			ref: node,
 			lastWidth: node.offsetWidth,
 			lastHeight: node.offsetHeight
 		});
-		this._callback( node );
+		this._callback(node);
 	};
-	
-	ResizeObserver.prototype.unobserve = function( node ) {
-		for( var i = 0; i < this._trackedNodes.length; i++ ) {
-			if( this._trackedNodes[i].ref === node ) {
-				this._trackedNodes.splice( i, 1 );
+
+	ResizeObserver.prototype.unobserve = function(node) {
+		for (var i = 0; i < this._trackedNodes.length; i++) {
+			if (this._trackedNodes[i].ref === node) {
+				this._trackedNodes.splice(i, 1);
 				break;
 			}
 		}

--- a/d2l-tspan.js
+++ b/d2l-tspan.js
@@ -1,6 +1,6 @@
 import '@polymer/polymer/polymer-legacy.js';
 import './d2l-table-observer-behavior.js';
-import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import './d2l-tspan-resize-observer-polyfill.js';
 import './d2l-td.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14880,11 +14880,6 @@
         "resolve-from": "^1.0.0"
       }
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "stickyfilljs": "^2.1.0",
-    "resize-observer-polyfill": "^1.5.0"
+    "stickyfilljs": "^2.1.0"
   }
 }


### PR DESCRIPTION
Fixed `<tspan>` not resizing when its content changes size in non-Chrome browsers