### PR TITLE
Fix a11y of d2l-table

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -216,7 +216,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			<d2l-table-circle-button class="right action" icon="[[endIcon]]" on-tap="handleTapRight" tabindex="-1" aria-hidden="true" type="button"></d2l-table-circle-button>
 		</d2l-sticky-element>
 		<div id="wrapper" class="wrapper">
-			<div class="inner-wrapper"><slot></slot></div>
+			<div class="inner-wrapper" role$="[[_role]]"><slot></slot></div>
 		</div>
 	</template>
 	
@@ -360,6 +360,12 @@ Polymer({
 			type: Boolean,
 			reflectToAttribute: true
 		},
+
+		needsTable: {
+			type: Boolean,
+			value: false
+		},
+
 		/** IE and Edge requires the value to be 1 in some cases **/
 		/**
 			Background: In some occasions in IE and Edge, there is a
@@ -374,6 +380,10 @@ Polymer({
 		_stickyIsDisabled: {
 			type: Boolean,
 			computed: '_computeStickyIsDisabled(scrollbarLeft, scrollbarRight)'
+		},
+		_role: {
+			type: String,
+			computed: '_computeRole(needsTable)'
 		}
 	},
 
@@ -501,5 +511,9 @@ Polymer({
 
 	_computeStickyIsDisabled: function(scrollbarLeft, scrollbarRight) {
 		return Boolean(scrollbarLeft) && Boolean(scrollbarRight);
+	},
+
+	_computeRole: function(needsTable) {
+		return needsTable ? 'table' : null;
 	}
 });

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -161,7 +161,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 				};
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions="">
+		<d2l-scroll-wrapper show-actions="" needs-table>
 			<slot id="slot"></slot>
 		</d2l-scroll-wrapper>
 	</template>
@@ -176,13 +176,6 @@ Polymer({
 	],
 	listeners: {
 		'd2l-table-local-observer': '_handleLocalObserver'
-	},
-	properties: {
-		role: {
-			type: String,
-			value: 'table',
-			reflectToAttribute: true
-		}
 	},
 	__applyInQueue: false,
 	attached: function() {


### PR DESCRIPTION
There is likely a nicer way to do this, but all my attempts created larger issues so I went with this approach.

When `<d2l-table>` is used, there is no `<table>` element directly around the slotted content, so `role="table"` is added to the `d2l-table`. Unfortunately, there are too many levels between the `<d2l-table>` and the rest of the table elements, which causes some screenreader/browser combinations to not be able to see the table contents or navigate them.

This change has been tested successfully with:

- VO+Safari (iOS)
- VO+Safari (Mac)
- VO+Chrome (Mac)
- Talkback+Chrome (Android)

VO+FF (Mac) was tested, and it had slight improvement of reading the number of rows correctly, but otherwise still does not work. My understanding is this combination is not really a thing people use anyway because it's generally bad.

NVDA+FF should be checked but I don't have Windows.

[DE32120](https://rally1.rallydev.com/#/detail/defect/271201941996?fdp=true)