### PR TITLE
Add demo that shows the overrides problem

### DIFF
--- a/demo/overrides-demo.js
+++ b/demo/overrides-demo.js
@@ -1,0 +1,141 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import '../d2l-table.js';
+
+/**
+ * @customElement
+ * @polymer
+ */
+
+class OverridesDemo extends PolymerElement {
+	static get template() {
+		const evaluationHubActivitiesListTemplate = html`
+		<custom-style>
+			<style is="custom-style" include="d2l-table-style">
+				d2l-table-wrapper,
+				d2l-table {
+					--d2l-table-border: 3px solid purple;
+					--d2l-table-border-radius: 0;
+					--d2l-table-header-background-color: lightblue;
+					--d2l-table-body-background-color: pink;
+
+					--d2l-table-light-border: 3px solid blue;
+					--d2l-table-light-header-background-color: lavender;
+
+					--d2l-table-row-background-color-active: deeppink;
+					--d2l-table-row-border-color-active-selected: darkgreen;
+					--d2l-table-row-background-color-active-selected: seagreen;
+					--d2l-table-row-border-color-selected: red;
+					--d2l-table-row-background-color-selected: salmon;
+				}
+				.screenshots {
+				  display: inline-block;
+					margin: 20px;
+				}
+			</style>
+			</custom-style>
+			<div class="screenshots screenshot-small">
+				<!-- header only -->
+				<d2l-table-wrapper><table class="d2l-table" selectable>
+					<thead>
+					<tr>
+						<th>First Name</th>
+						<th>Middle Name</th>
+						<th>Last Name</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr>
+						<td>Darlene</td>
+						<td>Bridget</td>
+						<td>Waters</td>
+					</tr>
+					<tr selected>
+						<td>David</td>
+						<td>Robert</td>
+						<td>Sandoval</td>
+					</tr>
+					</tbody>
+				</table></d2l-table-wrapper>
+			</div>
+			<div class="screenshots screenshot-small">
+				<!-- using d2l-t* elements -->
+				<d2l-table selectable>
+					<d2l-thead>
+					<d2l-tr>
+						<d2l-th>First Name</d2l-th>
+						<d2l-th>Middle Name</d2l-th>
+						<d2l-th>Last Name</d2l-th>
+					</d2l-tr>
+					</d2l-thead>
+					<d2l-tbody>
+					<d2l-tr>
+						<d2l-td>Darlene</d2l-td>
+						<d2l-td>Bridget</d2l-td>
+						<d2l-td>Waters</d2l-td>
+					</d2l-tr>
+					<d2l-tr selected>
+						<d2l-td>David</d2l-td>
+						<d2l-td>Robert</d2l-td>
+						<d2l-td>Sandoval</d2l-td>
+					</d2l-tr>
+					</d2l-tbody>
+				</d2l-table>
+			</div>
+			<br>
+			<div class="screenshots screenshot-small">
+				<!-- header only -->
+				<d2l-table-wrapper type="light"><table class="d2l-table" selectable>
+					<thead>
+					<tr>
+						<th>First Name</th>
+						<th>Middle Name</th>
+						<th>Last Name</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr>
+						<td>Darlene</td>
+						<td>Bridget</td>
+						<td>Waters</td>
+					</tr>
+					<tr selected>
+						<td>David</td>
+						<td>Robert</td>
+						<td>Sandoval</td>
+					</tr>
+					</tbody>
+				</table></d2l-table-wrapper>
+			</div>
+			<div class="screenshots screenshot-small">
+				<!-- using d2l-t* elements -->
+				<d2l-table type="light" selectable>
+					<d2l-thead>
+					<d2l-tr>
+						<d2l-th>First Name</d2l-th>
+						<d2l-th>Middle Name</d2l-th>
+						<d2l-th>Last Name</d2l-th>
+					</d2l-tr>
+					</d2l-thead>
+					<d2l-tbody>
+					<d2l-tr>
+						<d2l-td>Darlene</d2l-td>
+						<d2l-td>Bridget</d2l-td>
+						<d2l-td>Waters</d2l-td>
+					</d2l-tr>
+					<d2l-tr selected>
+						<d2l-td>David</d2l-td>
+						<d2l-td>Robert</d2l-td>
+						<d2l-td>Sandoval</d2l-td>
+					</d2l-tr>
+					</d2l-tbody>
+				</d2l-table>
+			</div>
+		`;
+
+		evaluationHubActivitiesListTemplate.setAttribute('strip-whitespace', 'strip-whitespace');
+		return evaluationHubActivitiesListTemplate;
+	}
+	static get is() { return 'overrides-demo'; }
+}
+
+window.customElements.define(OverridesDemo.is, OverridesDemo);

--- a/demo/overrides.html
+++ b/demo/overrides.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script type="module">
+			import '../d2l-table.js';
+			import './overrides-demo.js';
+		</script>
+		<script src="./update-direction.js"></script>
+		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
+	</head>
+
+	<body unresolved class="d2l-typography">
+		<!-- FIXME(polymer-modulizer):
+		These imperative modules that innerHTML your HTML are
+		a hacky way to be sure that any mixins in included style
+		modules are ready before any elements that reference them are
+		instantiated, otherwise the CSS @apply mixin polyfill won't be
+		able to expand the underlying CSS custom properties.
+		See: https://github.com/Polymer/polymer-modulizer/issues/154
+		-->
+	<script type="module">
+const $_documentContainer = document.createElement('template');
+
+$_documentContainer.innerHTML = `<custom-style>
+			<style is="custom-style" include="d2l-table-style d2l-typography">
+				html {
+					font-size: 20px;
+				}
+
+				.screenshots {
+				  display: inline-block;
+					margin: 20px;
+				}
+
+			</style>
+		</custom-style>`;
+
+document.body.appendChild($_documentContainer.content);
+</script>
+		<script type="module">
+const $_documentContainer = document.createElement('template');
+
+$_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
+			<overrides-demo></overrides-demo>
+</div>`;
+
+document.body.appendChild($_documentContainer.content);
+</script>


### PR DESCRIPTION
I'm seeing an issue with overriding the css variables in table mixins (like https://github.com/BrightspaceUI/table/blob/master/d2l-table-shared-styles.js#L25), when using a Polymer 3 class-based component (the modularized components using `innerHTML` seem to work fine).  Adding a demo to highlight the problem, which currently looks like this:
![image](https://user-images.githubusercontent.com/13419300/54755585-9fe48800-4bbc-11e9-8599-ab5396363f35.png)

The fix is pretty simple, if we're ok with moving those specific styles out of `d2l-table-shared-styles.js` and into `d2l-table-style.js`