### PR TITLE
Fix table style overrides

### DIFF
--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -22,15 +22,12 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
 
 			--d2l-table-cell: {
-				border-top:var(--d2l-table-border);
-				border-right:var(--d2l-table-border);
 				display:table-cell;
 				vertical-align:middle;
 				padding: 0.5rem 1rem;
 				height: 41px; /* min-height to be 62px including border */
 			}
 			--d2l-table-light-cell: {
-				border-top: var(--d2l-table-light-border);
 				display: table-cell;
 				vertical-align: middle;
 				padding: 0.6rem;
@@ -41,13 +38,11 @@ $_documentContainer.innerHTML = `<custom-style>
 				color:var(--d2l-color-ferrite);
 				font-size:.7rem;
 				line-height:1rem;
-				background-color:var(--d2l-table-header-background-color);
 				margin:1rem 0;
 				padding: 0.5rem 1rem;
 				height: 27px; /* min-height to be 48px including border */
 			}
 			--d2l-table-light-header: {
-				background-color:var(--d2l-table-light-header-background-color);
 				color: var(--d2l-color-ferrite);
 				font-size: 0.7rem;
 				font-weight: normal;
@@ -70,11 +65,9 @@ $_documentContainer.innerHTML = `<custom-style>
 			}
 			--d2l-table-foot: {
 				display:table-footer-group;
-				background-color:var(--d2l-table-body-background-color);
 			}
 			--d2l-table-body: {
 				display: table-row-group;
-				background-color:var(--d2l-table-body-background-color);
 			}
 			--d2l-table-row: {
 				display:table-row;

--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -18,11 +18,13 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			.d2l-table > tfoot,
 			d2l-tfoot {
 				@apply --d2l-table-foot;
+				background-color:var(--d2l-table-body-background-color);
 			}
 
 			.d2l-table > tbody,
 			d2l-tbody {
 				@apply --d2l-table-body;
+				background-color:var(--d2l-table-body-background-color);
 			}
 
 			.d2l-table > * > tr,
@@ -35,6 +37,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table[type="default"] d2l-td,
 			d2l-table[type="default"] d2l-th {
 				@apply --d2l-table-cell;
+				border-top:var(--d2l-table-border);
+				border-right:var(--d2l-table-border);
 				font-weight: inherit;
 				text-align: left;
 			}
@@ -44,6 +48,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table[type="light"] d2l-td,
 			d2l-table[type="light"] d2l-th {
 				@apply --d2l-table-light-cell;
+				border-top: var(--d2l-table-light-border);
 				font-weight: inherit;
 				text-align: left;
 			}
@@ -76,6 +81,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table[type="default"] d2l-tr[header] > d2l-th {
 				font-family: inherit;
 				@apply --d2l-table-header;
+				background-color:var(--d2l-table-header-background-color);
 			}
 
 			d2l-table-wrapper[type="light"] .d2l-table > thead > tr > th,
@@ -84,6 +90,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table[type="light"] d2l-tr[header] > d2l-th {
 				font-family: inherit;
 				@apply --d2l-table-light-header;
+				background-color:var(--d2l-table-light-header-background-color);
 			}
 
 			d2l-table-wrapper[type="light"] .d2l-table > thead > tr.d2l-table-row-first > th,


### PR DESCRIPTION
Moving the css variables out of the mixins.  Demo now looks like this:
![image](https://user-images.githubusercontent.com/13419300/54761684-ecce5b80-4bc8-11e9-97b6-9414827e4af5.png)
Compared to (https://github.com/BrightspaceUI/table/pull/208)