### PR TITLE
Reduce galen tests duration by running longest tests first

### DIFF
--- a/table.test.js
+++ b/table.test.js
@@ -4,32 +4,11 @@
 
 var browsers = {
 	chrome: new LocalBrowserFactory({ browser: 'chrome', size: '768x768', tags: ['sticky'] }),
-	chromeWindows: new SauceBrowserFactory({
-		browser: 'Chrome',
-		platform: 'WIN10',
-		tags: ['sticky'],
-		desiredCapabilities: {
-			seleniumVersion: '3.14.0',
-			screenResolution: '1600x1200'
-		}
-	}),
 	ie11Windows: new SauceBrowserFactory({
 		browser: 'internet explorer',
 		version: '11',
 		platform: 'WIN10',
 		tags: ['sticky'],
-		desiredCapabilities: {
-			seleniumVersion: '3.14.0',
-			screenResolution: '1600x1200'
-		}
-	}),
-	// getSize doesn't work in Edge 18: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/20071753/
-	// Problem occurs for Edge 18.17763
-	edgeWindows: new SauceBrowserFactory({
-		browser: 'microsoftedge',
-		platform: 'WIN10',
-		browserVersion: '17.17134',
-		tags: ['no-d2l-shadow'],
 		desiredCapabilities: {
 			seleniumVersion: '3.14.0',
 			screenResolution: '1600x1200'
@@ -48,15 +27,36 @@ var browsers = {
 		browser: 'Safari',
 		platform: 'EL_CAPITAN',
 		tags: ['no-d2l-shadow', 'sticky']
+	}),
+	chromeWindows: new SauceBrowserFactory({
+		browser: 'Chrome',
+		platform: 'WIN10',
+		tags: ['sticky'],
+		desiredCapabilities: {
+			seleniumVersion: '3.14.0',
+			screenResolution: '1600x1200'
+		}
+	}),
+	// getSize doesn't work in Edge 18: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/20071753/
+	// Problem occurs for Edge 18.17763
+	edgeWindows: new SauceBrowserFactory({
+		browser: 'microsoftedge',
+		platform: 'WIN10',
+		browserVersion: '17.17134',
+		tags: ['no-d2l-shadow'],
+		desiredCapabilities: {
+			seleniumVersion: '3.14.0',
+			screenResolution: '1600x1200'
+		}
 	})
 };
 
 var cssBrowsers = {
 	cssChrome: browsers.chrome,
-	cssChromeWindows: browsers.chromeWindows,
-	cssedgeWindows: browsers.edgeWindows,
 	cssChromeMac: browsers.chromeMac,
-	cssSafariMac: browsers.safariMac
+	cssChromeWindows: browsers.chromeWindows,
+	cssSafariMac: browsers.safariMac,
+	cssedgeWindows: browsers.edgeWindows
 };
 
 var mainlineEndpoint = 'http://localhost:8080/components/d2l-table/demo/simple.html';


### PR DESCRIPTION
* Saves 1-2 minutes (when nothing else is running)