### PR TITLE
Fix sticky headers with relative elements

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -361,6 +361,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: 0;
+				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tr[header] th,
@@ -426,6 +427,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				top: -5px;
 				border-left: none;
 				border-top: none;
+				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
@@ -446,6 +448,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: -5px;
+				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] th,
@@ -454,6 +457,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: -3.5px;
+				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]) td,


### PR DESCRIPTION
There's an interesting behaviour when sticky elements co-exist with elements positioned relatively in the same sticky container. In grades, this manifests itself because our inputs are relatively positioned:

![Screen Shot 2021-02-09 at 1 16 30 PM](https://user-images.githubusercontent.com/5491151/107408665-456ab280-6ad9-11eb-965e-684ed18a0ec8.png)

Grades has [hacked around this](https://search.d2l.dev/xref/lms/le/grades/static/css/grade_object_render.css?r=2eebc24f#2) by overriding the `input` positioning to `static`. But this hack doesn't work with our `<d2l-input-number>` web component (which also uses relative positioning internally) because it can't pierce the shadow root.

The fix for this, as described [in this blog post](https://hackernoon.com/css-underdog-rule-position-sticky-0z2t3y7r) is to apply a `z-index` to the sticky element. Clearly this already happened somewhere because some of the sticky elements in here have a `z-index` already... just not the ones that the grades page uses. This applies it more consistently.