### PR TITLE
removing docs for last-row as it's no longer supported

### DIFF
--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -39,7 +39,6 @@ Attribute | Description
 `selected` | Apply selected style
 `active` | Apply active style
 `header` | Apply header style
-`last-row` | This row is to be treated as the bottom row in the case where CSS can't detect it. This should only happen if the last row(s) are hidden from view, and the table has no footer
 
 ## Styling
 

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -37,7 +37,6 @@ Attribute | Description
 `selected` | Apply selected style
 `active` | Apply active style
 `header` | Apply header style
-`last-row` | This row is to be treated as the bottom row in the case where CSS can't detect it. This should only happen if the last row(s) are hidden from view, and the table has no footer
 
 ## Styling
 


### PR DESCRIPTION
Putting `last-row` on a row in the table used to be required if there was crazy CSS hiding rows, but that functionality [was removed in early 2018](https://github.com/BrightspaceUI/table/pull/149). This just removes it from the docs so it doesn't confuse us again the next time we try to port this to something else. :)

I've remove the [usages in the LMS as well](https://search.d2l.dev/search?project=lms&full=%22last-row%22&defs=&refs=&path=&hist=&type=&xrd=&si=full&si=full) since they're also pointless.