### PR TITLE
feat: removing concept of "active" rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,6 @@ HTML:
 	<tr selected>
 		<td>selected</td>
 	</tr>
-	<tr active>
-		<td>active</td>
-	</tr>
-	<tr active selected>
-		<td>active and selected</td>
-	</tr>
 </table></d2l-table-wrapper>
 ```
 

--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -164,14 +164,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				border-bottom: var(--d2l-table-light-border);
 			}
 
-			/* active rows or un-selected hover rows */
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active],
+			/* un-selected hover rows */
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active],
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr:not([selected]):hover,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active],
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active],
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr:not([selected]):hover {
 				background-color: var(--d2l-table-row-background-color-active);
 			}
@@ -232,93 +228,55 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				border-bottom-color:var(--d2l-table-row-border-color-selected);
 			}
 
-			/* active + selected rows */
+			/* selectable + selected + hover rows */
 
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected],
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected],
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected],
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected],
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover {
 				background-color:var(--d2l-table-row-background-color-active-selected);
 			}
 
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-first,
-			[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-first,
 			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
 			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first {
 				border-right-color: var(--d2l-table-row-border-color-active-selected);
 			}
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
 			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
 			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
 				border-right-color: var(--d2l-table-border-color);
 			}
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-first,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-first,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first,
 			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
 			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
 				border-left-color: var(--d2l-table-row-border-color-active-selected);
 			}
 
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > td,
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > th,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] + tr > td,
-			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] + tr > th,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > d2l-td,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > d2l-th,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-td,
-			d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-th,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
 			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] > td,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] > th,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] + tr > td,
-			d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] + tr > th,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] > d2l-td,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] > d2l-th,
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-td,
-			d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-th,
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
 			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th {
 				border-top-color:var(--d2l-table-row-border-color-active-selected);
 			}
 
-			d2l-table-wrapper[type="default"] .d2l-table-row-last[active][selected] > td,
-			d2l-table-wrapper[type="default"] .d2l-table-row-last[active][selected] > th,
-			d2l-table[type="default"] .d2l-table-row-last[active][selected] > d2l-td,
-			d2l-table[type="default"] .d2l-table-row-last[active][selected] > d2l-th,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
 			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
 			d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,
 			d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-th,
-			d2l-table-wrapper[type="light"] .d2l-table-row-last[active][selected] > td,
-			d2l-table-wrapper[type="light"] .d2l-table-row-last[active][selected] > th,
-			d2l-table[type="light"] .d2l-table-row-last[active][selected] > d2l-td,
-			d2l-table[type="light"] .d2l-table-row-last[active][selected] > d2l-th,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
 			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
 			d2l-table[type="light"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -37,7 +37,6 @@ Attribute | Description
 Attribute | Description
 ----------|-------------
 `selected` | Apply selected style
-`active` | Apply active style
 `header` | Apply header style
 
 ## Styling
@@ -49,10 +48,7 @@ Custom property | Description | Default
 `--d2l-table-border` | Border | `1px solid var(--d2l-table-border-color);` |
 `--d2l-table-header-background-color` | Header background color (th elements under `<thead>` or `<tr header>`) | `var(--d2l-color-regolith);` |
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
-`--d2l-table-row-background-color-active` | Active row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine-plus-1)` |
-`--d2l-table-row-border-color-active-selected` | Active and Selected row border color | `var(--d2l-color-celestine-plus-1)` |
-`--d2l-table-row-background-color-active-selected` | Active and Selected row background color | `#EBF5FC` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
 
@@ -69,9 +65,6 @@ Custom property | Description | Default
 			--d2l-table-border-radius: 0;
 			--d2l-table-header-background-color: grey;
 			--d2l-table-body-background-color: blue;
-			--d2l-table-row-background-color-active: black;
-			--d2l-table-row-border-color-active-selected: red;
-			--d2l-table-row-background-color-active-selected: red;
 			--d2l-table-row-border-color-selected: black;
 			--d2l-table-row-background-color-selected: black;
 			--d2l-table-border-overflow: none;

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -35,7 +35,6 @@ Attribute | Description
 Attribute | Description
 ----------|-------------
 `selected` | Apply selected style
-`active` | Apply active style
 `header` | Apply header style
 
 ## Styling
@@ -47,10 +46,7 @@ Custom property | Description | Default
 `--d2l-table-border` | Border | `1px solid var(--d2l-table-border-color);` |
 `--d2l-table-header-background-color` | Header background color (th elements under `<thead>` or `<tr header>`) | `var(--d2l-color-regolith);` |
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
-`--d2l-table-row-background-color-active` | Active row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine-plus-1)` |
-`--d2l-table-row-border-color-active-selected` | Active and Selected row border color | `var(--d2l-color-celestine-plus-1)` |
-`--d2l-table-row-background-color-active-selected` | Active and Selected row background color | `#EBF5FC` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
 
@@ -67,9 +63,6 @@ Custom property | Description | Default
 			--d2l-table-border-radius: 0;
 			--d2l-table-header-background-color: grey;
 			--d2l-table-body-background-color: blue;
-			--d2l-table-row-background-color-active: black;
-			--d2l-table-row-border-color-active-selected: red;
-			--d2l-table-row-background-color-active-selected: red;
 			--d2l-table-row-border-color-selected: black;
 			--d2l-table-row-background-color-selected: black;
 			--d2l-table-border-overflow: none;

--- a/demo/index.html
+++ b/demo/index.html
@@ -419,67 +419,8 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 			</table></d2l-table-wrapper>
 		</div>
 
-		<!-- Selected and active rows -->
+		<!-- Selected rows -->
 		<div>
-			<!-- active only -->
-			<d2l-table-wrapper><table class="d2l-table">
-				<tbody>
-				<tr active="">
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<d2l-table-wrapper><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr active="">
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<d2l-table-wrapper><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr active="">
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<!-- selected only -->
 			<d2l-table-wrapper><table class="d2l-table">
 				<tbody>
 				<tr selected="">
@@ -531,66 +472,6 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 					<td>Baldwin</td>
 				</tr>
 				<tr selected="">
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<!-- selected and active -->
-			<d2l-table-wrapper><table class="d2l-table">
-				<tbody>
-				<tr active="" selected="">
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<div class="screenshots screenshot-rows">
-				<d2l-table-wrapper><table class="d2l-table">
-					<tbody>
-					<tr>
-						<td>Darlene</td>
-						<td>Bridget</td>
-						<td>Waters</td>
-					</tr>
-					<tr active="" selected="">
-						<td>Paula</td>
-						<td>Rose</td>
-						<td>Baldwin</td>
-					</tr>
-					<tr>
-						<td>David</td>
-						<td>Robert</td>
-						<td>Sandoval</td>
-					</tr>
-					</tbody>
-				</table></d2l-table-wrapper>
-			</div>
-			<d2l-table-wrapper><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr active="" selected="">
 					<td>David</td>
 					<td>Robert</td>
 					<td>Sandoval</td>
@@ -601,7 +482,6 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 
 		<!-- Sorting icons -->
 		<div class="screenshots screenshot-sort">
-			<!-- active only -->
 			<d2l-table-wrapper><table class="d2l-table">
 				<thead>
 					<tr><th>
@@ -654,7 +534,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 						<td>of 10</td>
 						<td>-%</td>
 					</tr>
-					<tr active="">
+					<tr>
 						<td>Lourdes</td>
 						<td>Beadle</td>
 						<td>of 10</td>
@@ -689,7 +569,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 					</tr>
 				</tfoot>
 				<tbody>
-					<tr active="" selected="">
+					<tr selected="">
 						<td>Aarons</td>
 						<td>Meghan</td>
 						<td>of 10</td>

--- a/demo/light.html
+++ b/demo/light.html
@@ -425,70 +425,8 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 			</table></d2l-table-wrapper>
 		</div>
 
-		<p>Selected and Active Rows</p>
+		<p>Selected Rows</p>
 		<div>
-			<p>Active only</p>
-			<d2l-table-wrapper type="light"><table class="d2l-table">
-				<tbody>
-				<tr active="">
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<br>
-			<d2l-table-wrapper type="light"><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr active="">
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<br>
-			<d2l-table-wrapper type="light"><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr active="">
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-
-			<p>Selected only</p>
 			<d2l-table-wrapper type="light"><table class="d2l-table">
 				<tbody>
 				<tr selected="">
@@ -542,69 +480,6 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 					<td>Baldwin</td>
 				</tr>
 				<tr selected="">
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-
-			<p>Selected and active</p>
-			<d2l-table-wrapper type="light"><table class="d2l-table">
-				<tbody>
-				<tr active="" selected="">
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr>
-					<td>David</td>
-					<td>Robert</td>
-					<td>Sandoval</td>
-				</tr>
-				</tbody>
-			</table></d2l-table-wrapper>
-			<br>
-			<div class="screenshots screenshot-rows">
-				<d2l-table-wrapper type="light"><table class="d2l-table">
-					<tbody>
-					<tr>
-						<td>Darlene</td>
-						<td>Bridget</td>
-						<td>Waters</td>
-					</tr>
-					<tr active="" selected="">
-						<td>Paula</td>
-						<td>Rose</td>
-						<td>Baldwin</td>
-					</tr>
-					<tr>
-						<td>David</td>
-						<td>Robert</td>
-						<td>Sandoval</td>
-					</tr>
-					</tbody>
-				</table></d2l-table-wrapper>
-			</div>
-			<br>
-			<d2l-table-wrapper type="light"><table class="d2l-table">
-				<tbody>
-				<tr>
-					<td>Darlene</td>
-					<td>Bridget</td>
-					<td>Waters</td>
-				</tr>
-				<tr>
-					<td>Paula</td>
-					<td>Rose</td>
-					<td>Baldwin</td>
-				</tr>
-				<tr active="" selected="">
 					<td>David</td>
 					<td>Robert</td>
 					<td>Sandoval</td>
@@ -615,7 +490,6 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 
 		<p>Sorting icons</p>
 		<div class="screenshots screenshot-sort">
-			<p>Active only</p>
 			<d2l-table-wrapper type="light"><table class="d2l-table">
 				<thead>
 					<tr><th>
@@ -668,7 +542,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 						<td>of 10</td>
 						<td>-%</td>
 					</tr>
-					<tr active="">
+					<tr>
 						<td>Lourdes</td>
 						<td>Beadle</td>
 						<td>of 10</td>
@@ -704,7 +578,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 					</tr>
 				</tfoot>
 				<tbody>
-					<tr active="" selected="">
+					<tr selected="">
 						<td>Aarons</td>
 						<td>Meghan</td>
 						<td>of 10</td>

--- a/demo/overrides-demo.js
+++ b/demo/overrides-demo.js
@@ -21,9 +21,6 @@ class OverridesDemo extends PolymerElement {
 					--d2l-table-light-border: 3px solid blue;
 					--d2l-table-light-header-background-color: lavender;
 
-					--d2l-table-row-background-color-active: deeppink;
-					--d2l-table-row-border-color-active-selected: darkgreen;
-					--d2l-table-row-background-color-active-selected: seagreen;
 					--d2l-table-row-border-color-selected: red;
 					--d2l-table-row-background-color-selected: salmon;
 				}

--- a/demo/simple.html
+++ b/demo/simple.html
@@ -216,7 +216,7 @@ document.body.appendChild($_documentContainer.content);
 			<div class="screenshots screenshot-rows">
 				<d2l-table-wrapper><table class="d2l-table">
 					<tbody>
-					<tr active="" selected="">
+					<tr selected="">
 						<td><span> </span></td>
 						<td><span> </span></td>
 						<td><span> </span></td>
@@ -226,7 +226,7 @@ document.body.appendChild($_documentContainer.content);
 						<td><span> </span></td>
 						<td><span> </span></td>
 					</tr>
-					<tr active="" selected="">
+					<tr selected="">
 						<td><span> </span></td>
 						<td><span> </span></td>
 						<td><span> </span></td>
@@ -236,12 +236,12 @@ document.body.appendChild($_documentContainer.content);
 						<td><span> </span></td>
 						<td><span> </span></td>
 					</tr>
-					<tr active="" selected="">
+					<tr selected="">
 						<td><span> </span></td>
 						<td><span> </span></td>
 						<td><span> </span></td>
 					</tr>
-					<tr active="" selected="">
+					<tr selected="">
 						<td><span> </span></td>
 						<td><span> </span></td>
 						<td><span> </span></td>


### PR DESCRIPTION
In reviewing table's variants, I noticed was that the concept of "active" rows is completely redundant as its style is identical to "selected" rows (background of Celestine+2 and border of Celestine+1). Active rows also weren't in the original design, and don't seem to serve a purpose. For those reasons, we'd like to remove the concept of "active" entirely.

There's a single usage in manager-view where they're applying both "active" AND "selected". I've [put up a pull request](https://github.com/Brightspace/manager-view-fra/pull/2087) to address that.