### PR TITLE
feat: removing "selectable" functionality

### DIFF
--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -15,9 +15,6 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-light-header-background-color: #fff;
 
 			--d2l-table-body-background-color: #fff;
-			--d2l-table-row-background-color-active: var(--d2l-color-celestine-plus-2);
-			--d2l-table-row-border-color-active-selected: var(--d2l-color-celestine-plus-1);
-			--d2l-table-row-background-color-active-selected: #EBF5FC;
 			--d2l-table-row-border-color-selected: var(--d2l-color-celestine-plus-1);
 			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
 

--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -164,14 +164,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				border-bottom: var(--d2l-table-light-border);
 			}
 
-			/* un-selected hover rows */
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr:not([selected]):hover,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr:not([selected]):hover {
-				background-color: var(--d2l-table-row-background-color-active);
-			}
-
 			/* selected rows */
 
 			d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected],
@@ -226,62 +218,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table[type="light"] .d2l-table-row-last[selected] > d2l-td,
 			d2l-table[type="light"] .d2l-table-row-last[selected] > d2l-th {
 				border-bottom-color:var(--d2l-table-row-border-color-selected);
-			}
-
-			/* selectable + selected + hover rows */
-
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover {
-				background-color:var(--d2l-table-row-background-color-active-selected);
-			}
-
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
-			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first {
-				border-right-color: var(--d2l-table-row-border-color-active-selected);
-			}
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
-				border-right-color: var(--d2l-table-border-color);
-			}
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first,
-			[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
-			[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
-				border-left-color: var(--d2l-table-row-border-color-active-selected);
-			}
-
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
-			d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
-			d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th {
-				border-top-color:var(--d2l-table-row-border-color-active-selected);
-			}
-
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
-			d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
-			d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,
-			d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-th,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
-			d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
-			d2l-table[type="light"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,
-			d2l-table[type="light"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-th {
-				border-bottom-color:var(--d2l-table-row-border-color-active-selected);
 			}
 
 			/* no-column-border */

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -29,7 +29,6 @@
 
 Attribute | Description
 ----------|-------------
-`selectable` | Add hover effect for rows
 `type` | Table style - "default" or "light"
 
 ### Row Attributes

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -27,7 +27,6 @@
 
 Attribute | Description
 ----------|-------------
-`selectable` | Add hover effect for rows
 `type` | Table style - "default" or "light"
 
 ### Row Attributes

--- a/demo/index.html
+++ b/demo/index.html
@@ -636,7 +636,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 			</div>
 
 			<p>Large Table</p>
-			<d2l-table-wrapper><table class="d2l-table" selectable="">
+			<d2l-table-wrapper><table class="d2l-table">
 				<caption>Table Caption</caption>
 				<colgroup></colgroup>
 				<colgroup></colgroup>

--- a/demo/light.html
+++ b/demo/light.html
@@ -646,7 +646,7 @@ $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 			</div>
 
 			<p>Large Table</p>
-			<d2l-table-wrapper type="light"><table class="d2l-table" selectable="">
+			<d2l-table-wrapper type="light"><table class="d2l-table">
 				<caption>Table Caption</caption>
 				<colgroup></colgroup>
 				<colgroup></colgroup>

--- a/demo/overrides-demo.js
+++ b/demo/overrides-demo.js
@@ -32,7 +32,7 @@ class OverridesDemo extends PolymerElement {
 			</custom-style>
 			<div class="screenshots screenshot-small">
 				<!-- header only -->
-				<d2l-table-wrapper><table class="d2l-table" selectable>
+				<d2l-table-wrapper><table class="d2l-table">
 					<thead>
 					<tr>
 						<th>First Name</th>
@@ -56,7 +56,7 @@ class OverridesDemo extends PolymerElement {
 			</div>
 			<div class="screenshots screenshot-small">
 				<!-- using d2l-t* elements -->
-				<d2l-table selectable>
+				<d2l-table>
 					<d2l-thead>
 					<d2l-tr>
 						<d2l-th>First Name</d2l-th>
@@ -81,7 +81,7 @@ class OverridesDemo extends PolymerElement {
 			<br>
 			<div class="screenshots screenshot-small">
 				<!-- header only -->
-				<d2l-table-wrapper type="light"><table class="d2l-table" selectable>
+				<d2l-table-wrapper type="light"><table class="d2l-table">
 					<thead>
 					<tr>
 						<th>First Name</th>
@@ -105,7 +105,7 @@ class OverridesDemo extends PolymerElement {
 			</div>
 			<div class="screenshots screenshot-small">
 				<!-- using d2l-t* elements -->
-				<d2l-table type="light" selectable>
+				<d2l-table type="light">
 					<d2l-thead>
 					<d2l-tr>
 						<d2l-th>First Name</d2l-th>

--- a/demo/responsive-demo.js
+++ b/demo/responsive-demo.js
@@ -12,7 +12,7 @@ export function getTemplate(tableType) {
 				}
 			</style>
 			<h3>Small Table</h3>
-			<d2l-table-wrapper type="${tableType}"><table class="d2l-table" selectable="">
+			<d2l-table-wrapper type="${tableType}"><table class="d2l-table">
 				<thead>
 				<tr>
 					<th>Column header 1</th>
@@ -33,7 +33,7 @@ export function getTemplate(tableType) {
 				</tbody>
 			</table></d2l-table-wrapper>
 			<h3>Simple Table</h3>
-			<d2l-table-wrapper type="${tableType}"><table class="d2l-table" selectable="">
+			<d2l-table-wrapper type="${tableType}"><table class="d2l-table">
 				<tbody><tr>
 					<th>Column header 1</th>
 					<th>Column header 2</th>
@@ -44,7 +44,7 @@ export function getTemplate(tableType) {
 				</tr>
 			</tbody></table></d2l-table-wrapper>
 			<h3>Medium Table</h3>
-			<d2l-table-wrapper type="${tableType}"><table class="d2l-table" selectable="">
+			<d2l-table-wrapper type="${tableType}"><table class="d2l-table">
 				<thead>
 				<tr>
 					<th>Column header 1</th>
@@ -71,7 +71,7 @@ export function getTemplate(tableType) {
 				</tbody>
 			</table></d2l-table-wrapper>
 			<h3>Large Table</h3>
-			<d2l-table-wrapper type="${tableType}"><table class="d2l-table" selectable="">
+			<d2l-table-wrapper type="${tableType}"><table class="d2l-table">
 				<thead>
 				<tr>
 					<th>Column header 1</th>

--- a/demo/sticky-headers-demo.js
+++ b/demo/sticky-headers-demo.js
@@ -18,7 +18,7 @@ export function getTemplate(tableType) {
 
 				<p>Just Headers</p>
 				<d2l-table-wrapper sticky-headers="" type="${tableType}">
-					<table class="d2l-table" selectable="">
+					<table class="d2l-table">
 						<tbody>
 							<tr header="">
 								<th>Column header 1 Really Really REALLY long</th>
@@ -378,7 +378,7 @@ export function getTemplate(tableType) {
 
 				<p>Headers and First Column</p>
 				<d2l-table-wrapper sticky-headers="" type="${tableType}">
-					<table class="d2l-table" selectable="">
+					<table class="d2l-table">
 						<tbody>
 							<tr header="">
 								<th sticky="">Column header 1 Really Really REALLY long</th>
@@ -846,7 +846,7 @@ export function getTemplate(tableType) {
 
 				<p>Multi-Header Table</p>
 				<d2l-table-wrapper sticky-headers="" type="${tableType}">
-					<table id="multi" class="d2l-table" selectable="">
+					<table id="multi" class="d2l-table">
 						<thead>
 							<tr>
 								<th rowspan="2">Column header 1 Really Really REALLY long</th>


### PR DESCRIPTION
Similar to removing the concept of "active" rows, I'm also removing support for the "selectable" attribute at the table level. This attribute went on the `<table class="d2l-table" selectable>` or `<d2l-table selectable>` elements and when present it applied "selected" styles to rows when the user hovered over them.

This was again not part of the table design, and as you can see by the CSS I've removed in this PR it added a fair amount of complexity.

Plus, it only ended up getting used in one place in [public-fra](https://search.d2l.dev/xref/Brightspace/publish-fra/src/publish-packages.js?r=226464e8#398), where they're using it as a CSS selector (not an attribute) and have copied table's styles and modified them to make that work. So they won't even be impacted by this removal.