### PR TITLE
fix: line-height of header cells should be 0.9rem

### DIFF
--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -34,7 +34,7 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-header: {
 				color:var(--d2l-color-ferrite);
 				font-size:.7rem;
-				line-height:1rem;
+				line-height: 0.9rem;
 				margin:1rem 0;
 				padding: 0.5rem 1rem;
 				height: 27px; /* min-height to be 48px including border */
@@ -43,7 +43,7 @@ $_documentContainer.innerHTML = `<custom-style>
 				color: var(--d2l-color-ferrite);
 				font-size: 0.7rem;
 				font-weight: normal;
-				line-height: 1rem;
+				line-height: 0.9rem;
 				padding: 0.6rem;
 				height: 1.15rem; /* min-height to be 48px including border */
 			}


### PR DESCRIPTION
Tweaking the table header (both normal and light) line-height to be `0.9rem` instead of `1rem` [as per the design](http://design.d2l/components/tables/).