### PR TITLE
fix: changing selected border colours to celestine

### DIFF
--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -15,7 +15,7 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-light-header-background-color: #fff;
 
 			--d2l-table-body-background-color: #fff;
-			--d2l-table-row-border-color-selected: var(--d2l-color-celestine-plus-1);
+			--d2l-table-row-border-color-selected: var(--d2l-color-celestine);
 			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
 
 			--d2l-table-cell: {

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -47,7 +47,7 @@ Custom property | Description | Default
 `--d2l-table-border` | Border | `1px solid var(--d2l-table-border-color);` |
 `--d2l-table-header-background-color` | Header background color (th elements under `<thead>` or `<tr header>`) | `var(--d2l-color-regolith);` |
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
-`--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine-plus-1)` |
+`--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine)` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
 

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -45,7 +45,7 @@ Custom property | Description | Default
 `--d2l-table-border` | Border | `1px solid var(--d2l-table-border-color);` |
 `--d2l-table-header-background-color` | Header background color (th elements under `<thead>` or `<tr header>`) | `var(--d2l-color-regolith);` |
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
-`--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine-plus-1)` |
+`--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine)` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
 `--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
 


### PR DESCRIPTION
Another small tweak to align the selected row border/outline colours with the design. They should have been Celestine, not Celestine+1.