### PR TITLE
fix: replacing table style mixins with inline styles

### DIFF
--- a/d2l-table-col-sort-button.js
+++ b/d2l-table-col-sort-button.js
@@ -15,37 +15,29 @@ const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="d2l-table-col-sort-button">
 	<template strip-whitespace="">
 		<style>
-			:host {
-				--d2l-table-col-sort-button: {
-					background-color: transparent;
-					border: none;
-					cursor: pointer;
-					display: inline-block;
-					font-size: inherit;
-					color: inherit;
-					letter-spacing: inherit;
-					margin: 0;
-					padding: 0;
-					text-decoration: none;
-				};
-				--d2l-table-col-sort-button-hover: {
-					outline-style: none;
-					text-decoration: underline;
-				};
-			}
 			button::-moz-focus-inner {
 				border: 0;
 			}
 			button {
+				background-color: transparent;
+				border: none;
+				color: inherit;
+				cursor: pointer;
+				display: inline-block;
 				font-family: inherit;
-				@apply --d2l-table-col-sort-button;
+				font-size: inherit;
+				letter-spacing: inherit;
+				margin: 0;
+				padding: 0;
+				text-decoration: none;
 			}
 			button:disabled {
 				opacity: 0.5;
 			}
 			button:hover,
 			button:focus {
-				@apply --d2l-table-col-sort-button-hover;
+				outline-style: none;
+				text-decoration: underline;
 			}
 			[hidden] {
 				display: none;

--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -17,16 +17,6 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-body-background-color: #fff;
 			--d2l-table-row-border-color-selected: var(--d2l-color-celestine);
 			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
-
-			--d2l-table: {
-				background-color:transparent;
-				border-collapse:separate!important;
-				border-spacing:0;
-				display:table;
-				font-size: 0.8rem;
-				font-weight: 400;
-				width:100%;
-			}
 		}
 	</style>
 </custom-style>`;

--- a/d2l-table-shared-styles.js
+++ b/d2l-table-shared-styles.js
@@ -18,36 +18,6 @@ $_documentContainer.innerHTML = `<custom-style>
 			--d2l-table-row-border-color-selected: var(--d2l-color-celestine);
 			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
 
-			--d2l-table-cell: {
-				display:table-cell;
-				vertical-align:middle;
-				padding: 0.5rem 1rem;
-				height: 41px; /* min-height to be 62px including border */
-			}
-			--d2l-table-light-cell: {
-				display: table-cell;
-				vertical-align: middle;
-				padding: 0.6rem;
-				height: 1.15rem; /* min-height to be 48px including border */
-			}
-
-			--d2l-table-header: {
-				color:var(--d2l-color-ferrite);
-				font-size:.7rem;
-				line-height: 0.9rem;
-				margin:1rem 0;
-				padding: 0.5rem 1rem;
-				height: 27px; /* min-height to be 48px including border */
-			}
-			--d2l-table-light-header: {
-				color: var(--d2l-color-ferrite);
-				font-size: 0.7rem;
-				font-weight: normal;
-				line-height: 0.9rem;
-				padding: 0.6rem;
-				height: 1.15rem; /* min-height to be 48px including border */
-			}
-
 			--d2l-table: {
 				background-color:transparent;
 				border-collapse:separate!important;
@@ -56,18 +26,6 @@ $_documentContainer.innerHTML = `<custom-style>
 				font-size: 0.8rem;
 				font-weight: 400;
 				width:100%;
-			}
-			--d2l-table-head: {
-				display:table-header-group;
-			}
-			--d2l-table-foot: {
-				display:table-footer-group;
-			}
-			--d2l-table-body: {
-				display: table-row-group;
-			}
-			--d2l-table-row: {
-				display:table-row;
 			}
 		}
 	</style>

--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -7,50 +7,62 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 	<template>
 		<style>
 			.d2l-table {
-				@apply --d2l-table;
+				background-color: transparent;
+				border-collapse: separate!important;
+				border-spacing: 0;
+				display: table;
+				font-size: 0.8rem;
+				font-weight: 400;
+				width: 100%;
 			}
 
 			.d2l-table > thead,
 			d2l-thead {
-				@apply --d2l-table-head;
+				display: table-header-group;
 			}
 
 			.d2l-table > tfoot,
 			d2l-tfoot {
-				@apply --d2l-table-foot;
-				background-color:var(--d2l-table-body-background-color);
+				background-color: var(--d2l-table-body-background-color);
+				display: table-footer-group;
 			}
 
 			.d2l-table > tbody,
 			d2l-tbody {
-				@apply --d2l-table-body;
-				background-color:var(--d2l-table-body-background-color);
+				background-color: var(--d2l-table-body-background-color);
+				display: table-row-group;
 			}
 
 			.d2l-table > * > tr,
 			d2l-tr {
-				@apply --d2l-table-row;
+				display: table-row;
 			}
 
 			d2l-table-wrapper[type="default"] .d2l-table > * > tr > td,
 			d2l-table-wrapper[type="default"] .d2l-table > * > tr > th,
 			d2l-table[type="default"] d2l-td,
 			d2l-table[type="default"] d2l-th {
-				@apply --d2l-table-cell;
-				border-top:var(--d2l-table-border);
-				border-right:var(--d2l-table-border);
+				border-top: var(--d2l-table-border);
+				border-right: var(--d2l-table-border);
+				display: table-cell;
 				font-weight: inherit;
+				height: 41px; /* min-height to be 62px including border */
+				padding: 0.5rem 1rem;
 				text-align: left;
+				vertical-align: middle;
 			}
 
 			d2l-table-wrapper[type="light"] .d2l-table > * > tr > td,
 			d2l-table-wrapper[type="light"] .d2l-table > * > tr > th,
 			d2l-table[type="light"] d2l-td,
 			d2l-table[type="light"] d2l-th {
-				@apply --d2l-table-light-cell;
 				border-top: var(--d2l-table-light-border);
+				display: table-cell;
 				font-weight: inherit;
+				height: 1.15rem; /* min-height to be 48px including border */
+				padding: 0.6rem;
 				text-align: left;
+				vertical-align: middle;
 			}
 
 			d2l-table-wrapper[type="default"] .d2l-table-cell-first,
@@ -79,18 +91,28 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table-wrapper[type="default"] .d2l-table > * > tr[header] > th,
 			d2l-table[type="default"] d2l-thead > d2l-tr > d2l-th,
 			d2l-table[type="default"] d2l-tr[header] > d2l-th {
+				background-color: var(--d2l-table-header-background-color);
+				color: var(--d2l-color-ferrite);
 				font-family: inherit;
-				@apply --d2l-table-header;
-				background-color:var(--d2l-table-header-background-color);
+				font-size: 0.7rem;
+				line-height: 0.9rem;
+				margin: 1rem 0;
+				padding: 0.5rem 1rem;
+				height: 27px; /* min-height to be 48px including border */
 			}
 
 			d2l-table-wrapper[type="light"] .d2l-table > thead > tr > th,
 			d2l-table-wrapper[type="light"] .d2l-table > * > tr[header] > th,
 			d2l-table[type="light"] d2l-thead > d2l-tr > d2l-th,
 			d2l-table[type="light"] d2l-tr[header] > d2l-th {
+				background-color: var(--d2l-table-light-header-background-color);
+				color: var(--d2l-color-ferrite);
 				font-family: inherit;
-				@apply --d2l-table-light-header;
-				background-color:var(--d2l-table-light-header-background-color);
+				font-size: 0.7rem;
+				font-weight: normal;
+				height: 1.15rem; /* min-height to be 48px including border */
+				line-height: 0.9rem;
+				padding: 0.6rem;
 			}
 
 			d2l-table-wrapper[type="light"] .d2l-table > thead > tr.d2l-table-row-first > th,

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -151,7 +151,13 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
 
 				--d2l-scroll-wrapper-inner: {
-					@apply --d2l-table;
+					background-color: transparent;
+					border-collapse: separate!important;
+					border-spacing: 0;
+					display: table;
+					font-size: 0.8rem;
+					font-weight: 400;
+					width: 100%;
 				};
 			}
 		</style>


### PR DESCRIPTION
When these components move to Lit, we lose support for Polymer's style mixins. So they either need to go away because they were not actually used (best case!), or instead expose CSS variables for each thing that places were overriding.

Luckily with the table mixins nothing was actually using or setting them, so they can just move to inline styles. Beyond all the places that just copy-pasted these styles verbatim, there is [one usage](https://search.d2l.dev/xref/Brightspace/insights-engagement-dashboard/components/table.js?r=2281dfce#188) where they're `@apply --d2l-table`. I looked into it though and it was just a mistake as the table styles aren't even included -- the team will be removing it shortly.

Scroll-wrapper is going to be another story entirely, which is why I'm not handling it here. Almost everything about it is customized via the style mixins from multiple places. I'm going to need to untangle them individually to try and figure out what's going on.