### PR TITLE
fix: sticky first column must be above other sticky headers

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -424,7 +424,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] th[sticky],
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] td[sticky],
 			d2l-table-wrapper[type="light"][sticky-headers] thead > tr > th[sticky] {
-				z-index: 3;
+				z-index: 4; /* one higher so other header cells go under it */
 				left: 0;
 			}
 


### PR DESCRIPTION
This was a regression caused by the [fix for numeric inputs](https://github.com/BrightspaceUI/table/pull/220). By applying a `z-index` of 3 to all the sticky headers, when a header itself is sticky (like when the first column is sticky), they have the same `z-index` and it no longer goes "under" the other header cells.

Problem:
![Screen Shot 2021-03-17 at 2 37 46 PM](https://user-images.githubusercontent.com/5491151/111520777-ce0aed00-872e-11eb-8f2a-1db955f911e1.png)

The fix involves bumping that sticky header column `z-index` up by 1:
![Screen Shot 2021-03-17 at 2 37 30 PM](https://user-images.githubusercontent.com/5491151/111520827-da8f4580-872e-11eb-9b3d-9a71535bdec6.png)

I'm hoping these types of regressions can be avoided in the future with visual diffs.