### PR TITLE
feat: showing dashed borders whenever "has-actions"

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -23,18 +23,6 @@
 	<link rel="import" href="d2l-scroll-wrapper.html">
 	<style>
 		#scroll-wrapper {
-			--d2l-scroll-wrapper-h-scroll: {
-				/* styles to apply when horizontal scrollbar appears *\/
-			};
-
-			/* Note that the left/right styles are applied at the same time if there is no scrollbar *\/
-			--d2l-scroll-wrapper-left: {
-				/* styles to apply when scrolled to the left *\/
-			};
-			--d2l-scroll-wrapper-right: {
-				/* styles to apply when scrolled to the right *\/
-			};
-
 			--d2l-scroll-wrapper-action: {
 				/* styles for the left/right action buttons *\/
 			};
@@ -149,19 +137,31 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			:host([h-scrollbar]) .wrapper {
 				@apply --d2l-scroll-wrapper-h-scroll;
 			}
-
-			:host([is-sticky][h-scrollbar]) .wrapper {
+			:host([is-sticky][h-scrollbar]) .wrapper,
+			:host([is-sticky][h-scrollbar][overflow-border]) .wrapper {
 				border-right: none;
+			}
+			:host([h-scrollbar][overflow-border]) .wrapper {
+				border-left: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
+				border-right: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
 			}
 
 			:host([is-rtl][scrollbar-right]) .wrapper,
 			:host([scrollbar-left]) .wrapper {
 				@apply --d2l-scroll-wrapper-left;
 			}
+			:host([is-rtl][scrollbar-right][overflow-border]) .wrapper,
+			:host(:not([is-rtl])[scrollbar-left][overflow-border]) .wrapper {
+				border-left: none;
+			}
 
 			:host([is-rtl][scrollbar-left]) .wrapper,
 			:host([scrollbar-right]) .wrapper {
 				@apply --d2l-scroll-wrapper-right;
+			}
+			:host([is-rtl][scrollbar-left][overflow-border]) .wrapper,
+			:host(:not([is-rtl])[scrollbar-right][overflow-border]) .wrapper {
+				border-right: none;
 			}
 
 			.action {
@@ -341,6 +341,12 @@ Polymer({
 		endIcon: {
 			type: String,
 			value: 'd2l-tier1:chevron-right'
+		},
+
+		overflowBorder: {
+			type: Boolean,
+			value: false,
+			reflectToAttribute: true
 		},
 
 		isRtl: {

--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -138,10 +138,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 				@apply --d2l-scroll-wrapper-h-scroll;
 			}
 			:host([is-sticky][h-scrollbar]) .wrapper,
-			:host([is-sticky][h-scrollbar][overflow-border]) .wrapper {
+			:host([is-sticky][h-scrollbar][show-actions]) .wrapper {
 				border-right: none;
 			}
-			:host([h-scrollbar][overflow-border]) .wrapper {
+			:host([h-scrollbar][show-actions]) .wrapper {
 				border-left: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
 				border-right: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
 			}
@@ -150,8 +150,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			:host([scrollbar-left]) .wrapper {
 				@apply --d2l-scroll-wrapper-left;
 			}
-			:host([is-rtl][scrollbar-right][overflow-border]) .wrapper,
-			:host(:not([is-rtl])[scrollbar-left][overflow-border]) .wrapper {
+			:host([is-rtl][scrollbar-right][show-actions]) .wrapper,
+			:host(:not([is-rtl])[scrollbar-left][show-actions]) .wrapper {
 				border-left: none;
 			}
 
@@ -159,8 +159,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			:host([scrollbar-right]) .wrapper {
 				@apply --d2l-scroll-wrapper-right;
 			}
-			:host([is-rtl][scrollbar-left][overflow-border]) .wrapper,
-			:host(:not([is-rtl])[scrollbar-right][overflow-border]) .wrapper {
+			:host([is-rtl][scrollbar-left][show-actions]) .wrapper,
+			:host(:not([is-rtl])[scrollbar-right][show-actions]) .wrapper {
 				border-right: none;
 			}
 
@@ -341,12 +341,6 @@ Polymer({
 		endIcon: {
 			type: String,
 			value: 'd2l-tier1:chevron-right'
-		},
-
-		overflowBorder: {
-			type: Boolean,
-			value: false,
-			reflectToAttribute: true
 		},
 
 		isRtl: {

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -49,7 +49,7 @@ Custom property | Description | Default
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
 `--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine)` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
-`--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
+`--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px var(--d2l-color-mica)` |
 
 `--d2l-table-light-border-color` | Border color for light style | `var(--d2l-color-gypsum)` |
 `--d2l-table-light-border` | Border for light style | `1px solid var(--d2l-table-light-border-color)` |
@@ -122,28 +122,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-wrapper">
 				width: 100%;
 				--d2l-table-border-color: var(--d2l-color-mica);
 				--d2l-table-header-background-color: var(--d2l-color-regolith);
-				--d2l-table-border-overflow: dashed 1px #d3d9e3;
+				--d2l-table-border-overflow: dashed 1px var(--d2l-color-mica);
 			}
 			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-h-scroll: {
-					border-left: var(--d2l-table-border-overflow);
-					border-right: var(--d2l-table-border-overflow);
-				};
-				--d2l-scroll-wrapper-h-scroll-focus: {
-					border-left: var(--d2l-table-border-overflow-focus);
-					border-right: var(--d2l-table-border-overflow-focus);
-				};
-				--d2l-scroll-wrapper-left: {
-					border-left: none;
-				};
-				--d2l-scroll-wrapper-right: {
-					border-right: none;
-				};
 				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions="" is-sticky$="[[stickyHeaders]]">
+		<d2l-scroll-wrapper show-actions="" is-sticky$="[[stickyHeaders]]" overflow-border>
 			<slot id="slot"></slot>
 		</d2l-scroll-wrapper>
 	</template>

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -129,7 +129,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-wrapper">
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions="" is-sticky$="[[stickyHeaders]]" overflow-border>
+		<d2l-scroll-wrapper show-actions is-sticky$="[[stickyHeaders]]">
 			<slot id="slot"></slot>
 		</d2l-scroll-wrapper>
 	</template>

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -47,7 +47,7 @@ Custom property | Description | Default
 `--d2l-table-body-background-color` | Body background color (non-header) | `#fff` |
 `--d2l-table-row-border-color-selected` | Selected row border color | `var(--d2l-color-celestine)` |
 `--d2l-table-row-background-color-selected` | Selected row background color | `var(--d2l-color-celestine-plus-2)` |
-`--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px #d3d9e3` |
+`--d2l-table-border-overflow` | Border to show when the table overflows | `dashed 1px var(--d2l-color-mica)` |
 
 `--d2l-table-light-border-color` | Border color for light style | `var(--d2l-color-gypsum)` |
 `--d2l-table-light-border` | Border for light style | `1px solid var(--d2l-table-light-border-color)` |
@@ -127,26 +127,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 				width: 100%;
 				--d2l-table-border-color: var(--d2l-color-mica);
 				--d2l-table-header-background-color: var(--d2l-color-regolith);
-				--d2l-table-border-overflow: dashed 1px #d3d9e3;
+				--d2l-table-border-overflow: dashed 1px var(--d2l-color-mica);
 			}
 			:host([hidden]) {
 				display: none;
 			}
 			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-h-scroll: {
-					border-left: var(--d2l-table-border-overflow);
-					border-right: var(--d2l-table-border-overflow);
-				};
-				--d2l-scroll-wrapper-h-scroll-focus: {
-					border-left: var(--d2l-table-border-overflow-focus);
-					border-right: var(--d2l-table-border-overflow-focus);
-				};
-				--d2l-scroll-wrapper-left: {
-					border-left: none;
-				};
-				--d2l-scroll-wrapper-right: {
-					border-right: none;
-				};
 				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
 
@@ -161,7 +147,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 				};
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions="" needs-table>
+		<d2l-scroll-wrapper show-actions="" needs-table overflow-border>
 			<slot id="slot"></slot>
 		</d2l-scroll-wrapper>
 	</template>

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -147,7 +147,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 				};
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions="" needs-table overflow-border>
+		<d2l-scroll-wrapper show-actions needs-table>
 			<slot id="slot"></slot>
 		</d2l-scroll-wrapper>
 	</template>

--- a/demo/d2l-scroll-wrapper.html
+++ b/demo/d2l-scroll-wrapper.html
@@ -25,19 +25,7 @@ $_documentContainer.innerHTML = `<custom-style>
 				font-size: 20px;
 				--d2l-scroll-wrapper-background-color: red;
 				--d2l-scroll-wrapper-border-color: black;
-
-				--d2l-scroll-wrapper-h-scroll: {
-					border-left: 1px solid purple;
-					border-right: 1px solid purple;
-				};
-
-				--d2l-scroll-wrapper-left: {
-					border-right: none;
-				};
-
-				--d2l-scroll-wrapper-right: {
-					border-left: none;
-				};
+				--d2l-scroll-wrapper-overflow-border-color: purple;
 			}
 		</style>
 		</custom-style>`;
@@ -48,21 +36,21 @@ document.body.appendChild($_documentContainer.content);
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
-			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="">
+			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" overflow-border>
 				 <div style="width: 350px; height: 100px">
 					I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
 				 </div>
 			</d2l-scroll-wrapper>
 
 			<div dir="rtl">
-				<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="">
+				<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" overflow-border>
 					 <div style="width: 350px; height: 100px">
 						I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
 					 </div>
 				</d2l-scroll-wrapper>
 			</div>
 
-			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right">
+			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" overflow-border>
 				 <div style="width: 350px; height: 100px">
 					I have no action buttons
 				 </div>

--- a/demo/d2l-scroll-wrapper.html
+++ b/demo/d2l-scroll-wrapper.html
@@ -36,21 +36,21 @@ document.body.appendChild($_documentContainer.content);
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
-			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" overflow-border>
+			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions>
 				 <div style="width: 350px; height: 100px">
 					I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
 				 </div>
 			</d2l-scroll-wrapper>
 
 			<div dir="rtl">
-				<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" overflow-border>
+				<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions>
 					 <div style="width: 350px; height: 100px">
 						I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
 					 </div>
 				</d2l-scroll-wrapper>
 			</div>
 
-			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" overflow-border>
+			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" scroll-duration="500" scroll-amount="0.8" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right">
 				 <div style="width: 350px; height: 100px">
 					I have no action buttons
 				 </div>


### PR DESCRIPTION
The goal here is to remove the need for the various Polymer style mixins that `d2l-scroll-wrapper` uses. There are a lot of them, so this will take a bit.

The first three I'd like to starve out are all typically used together:
- `--d2l-scroll-wrapper-h-scroll`: applied whenever there's some form of horizontal scroll happening, and in almost every place it's used it applies a dashed right and left border
- `--d2l-scroll-wrapper-left`: applied when the scroll wrapper is scrolled all the way to the left, and typically just hides the left dashed border
- `--d2l-scroll-wrapper-right`: applied when the scroll wrapper is scrolled all the way to the right, and typically just hides the right dashed border

Here's an example of the dashed border getting applied to the right but not the left:
![Screen Shot 2021-03-18 at 4 25 05 PM](https://user-images.githubusercontent.com/5491151/111693162-a8511700-8806-11eb-944f-8156f98f37d6.png)

Bringing this together, `d2l-scroll-wrapper` doesn't show a dashed border by default when it's scrolled, but almost all places that use it manually apply a border using these 3 mixins.

- `<d2l-table>` and `<d2l-table-wrapper>` apply a `1px dashed #d3d9e3` border, which was our old "mica" and seems to have just not been updated to the new "mica" -- I talked to Jeff G and he confirmed that's what we want, so I've made that change here.
- [outcomes-overall-achievement](https://search.d2l.dev/xref/Brightspace/d2l-outcomes-overall-achievement/src/mastery-view-table/mastery-view-table.js?r=9463239d#162) and [rubrics](https://search.d2l.dev/xref/Brightspace/d2l-rubric/d2l-rubric-overall-score.js?r=153b78ef#127) also set a "mica" border
- [rubric editor](https://search.d2l.dev/xref/Brightspace/d2l-rubric/editor/d2l-rubric-editor-cell-styles.js?r=626043f2#17) sets the border colour to "galena", since the editor's borders are also darker. I've introduced a CSS variable `--d2l-scroll-wrapper-overflow-border-color` to allow this customization. The editor also sets `overflow-y: hidden`, the left/right margins to `1.5rem` (and unsets them when scrolled to the left/right)... I'll look into these separately and come up with a separate solution.
- [insights-engagement-dashboard](https://search.d2l.dev/xref/Brightspace/insights-engagement-dashboard/components/table.js?r=2281dfce#170) is doing the same thing as `d2l-table`, but it's setting the left border colour to "black" when scrolled all the way to the left instead of hiding it like everyone else does. Looking into it more (screenshot below in a comment), none of this is working as things are today, so hopefully these changes will help them out.

~So what I've done here is introduce a new `overflow-border` boolean attribute on `<d2l-scroll-wrapper>` that when set will automatically apply a dashed border in the correct place. The colour can be customized using a CSS variable, so rubric editor can use that. This removes the need for almost all the mixin usages and centralizes the logic around showing/hiding the border and its default colour. Table has been switched over to use this.~

**Update:** turns out whenever `show-actions` is set we want to show the dashed border, so instead of introducing a new attribute I'm just keying on that.

Once this merges, I'll go into the other usages and switch them over to use it as well -- I'll deal with rubric editor's margin/overflow-y stuff separately.