### PR TITLE
fix: margin collapse bug

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -85,9 +85,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 
 				--d2l-scroll-wrapper-sticky: {
 					height: 0;
-					/* height of button (40) + distance of button from top (10) + desired spacing (10) */
-					margin-bottom: 60px;
-					margin-top: -60px;
 					overflow: visible;
 				};
 


### PR DESCRIPTION
I noticed a bug when testing out other changes in engagement dashboard: when the scroll wrapper is right after an element with bottom margins, when the sticky buttons are visible the margins collapse. This results in weird spacing shifts when the buttons appear/disappear.

For example, with no overflow everything is great:
![Screen Shot 2021-03-19 at 5 00 39 PM](https://user-images.githubusercontent.com/5491151/111841968-2bd93980-88d5-11eb-88e7-7d9bf0011ed4.png)

And then with overflow notice the space between the heading and scroll wrapper is gone:
![Screen Shot 2021-03-19 at 5 04 13 PM](https://user-images.githubusercontent.com/5491151/111841980-309ded80-88d5-11eb-898f-b60b358f0483.png)

I've reverted table all the way back to several months ago and the issue still persists, so it's not related to any recent changes. All I can think of is that Chrome changed margin collapse behaviour, although it's also reproducible in all the other browsers so who knows.

The fix is to just remove the margins on the sticky buttons, which appears to now be unnecessary anyway. I think it might have originally been there for browsers who don't support sticky positioning. I'll revisit all this from scratch when I migrate this to Lit.

