### PR TITLE
fix: removing d2l-table's usage of scroll-wrapper-inner

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -213,7 +213,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			<d2l-table-circle-button class="right action" icon="[[endIcon]]" on-tap="handleTapRight" tabindex="-1" aria-hidden="true" type="button"></d2l-table-circle-button>
 		</d2l-sticky-element>
 		<div id="wrapper" class="wrapper">
-			<div class="inner-wrapper" role$="[[_role]]"><slot></slot></div>
+			<div class="inner-wrapper"><slot></slot></div>
 		</div>
 	</template>
 	
@@ -358,11 +358,6 @@ Polymer({
 			reflectToAttribute: true
 		},
 
-		needsTable: {
-			type: Boolean,
-			value: false
-		},
-
 		/** IE and Edge requires the value to be 1 in some cases **/
 		/**
 			Background: In some occasions in IE and Edge, there is a
@@ -377,10 +372,6 @@ Polymer({
 		_stickyIsDisabled: {
 			type: Boolean,
 			computed: '_computeStickyIsDisabled(scrollbarLeft, scrollbarRight)'
-		},
-		_role: {
-			type: String,
-			computed: '_computeRole(needsTable)'
 		}
 	},
 
@@ -508,9 +499,5 @@ Polymer({
 
 	_computeStickyIsDisabled: function(scrollbarLeft, scrollbarRight) {
 		return Boolean(scrollbarLeft) && Boolean(scrollbarRight);
-	},
-
-	_computeRole: function(needsTable) {
-		return needsTable ? 'table' : null;
 	}
 });

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -135,20 +135,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 			d2l-scroll-wrapper {
 				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
-
-				--d2l-scroll-wrapper-inner: {
-					background-color: transparent;
-					border-collapse: separate!important;
-					border-spacing: 0;
-					display: table;
-					font-size: 0.8rem;
-					font-weight: 400;
-					width: 100%;
-				};
+			}
+			.d2l-table-inner {
+				background-color: transparent;
+				border-collapse: separate!important;
+				border-spacing: 0;
+				display: table;
+				font-size: 0.8rem;
+				font-weight: 400;
+				width: 100%;
 			}
 		</style>
-		<d2l-scroll-wrapper show-actions needs-table>
-			<slot id="slot"></slot>
+		<d2l-scroll-wrapper show-actions>
+			<div class="d2l-table-inner" role="table"><slot id="slot"></slot></div>
 		</d2l-scroll-wrapper>
 	</template>
 


### PR DESCRIPTION
This kills two birds with one stone:

**1) Removes `<d2l-table>`'s usage of the `--d2l-scroll-wrapper-inner` Polymer style mixin**

There's still one more [in manager dashboard](https://search.d2l.dev/xref/Brightspace/manager-view-fra/src/table/mr-table-selectable.js?r=809d461e) that I need to sort out, but this particular usage was applying the styles we normally put on the native `<table class="d2l-table">` element -- except on scroll wrapper's "inner wrapper" `<div>`.

I worked around this by just applying those same styles to a `<div>` inside `<d2l-table>` instead.

**2) Eliminates the needs for the `needs-table` attribute on `d2l-scroll-wrapper`**

The `needs-table` attribute was only used from here to put `role="table"` on that same inner wrapper. I again moved it to a new `<div>` that can wrap the `<slot>`.
