### PR TITLE
fix: make scroll wrapper action offset always 10px

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -101,12 +101,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			:host([is-rtl]) .left.action,
 			.right.action {
 				left: auto;
-				right: var(--d2l-scroll-wrapper-action-offset, -15px);
+				right: -10px;
 			}
 
 			:host([is-rtl]) .right.action,
 			.left.action {
-				left: var(--d2l-scroll-wrapper-action-offset, -15px);
+				left: -10px;
 				right: auto;
 			}
 


### PR DESCRIPTION
After speaking with Jeff, we'd like this offset to just always be `-10px`, which will actually [match the original design](http://design.d2l/components/tables/).

![Screen Shot 2021-03-24 at 3 57 51 PM](https://user-images.githubusercontent.com/5491151/112376122-733b3d80-8cba-11eb-80b1-c3db8bd69145.png)

This variable is only used [in one place in BSI](https://search.d2l.dev/xref/Brightspace/brightspace-integration/web-components/d2l-table.js?r=bb01a27f#7), where it sets it to `-10px` -- so I'll be removing that once this releases.