### PR TITLE
fix: aligning action buttons with design intent

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -73,8 +73,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 				border-right: none;
 			}
 			:host([h-scrollbar][show-actions]) .wrapper {
-				border-left: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
-				border-right: 1px dashed var(--d2l-scroll-wrapper-overflow-border-color, var(--d2l-color-mica));
+				border-left: 1px dashed var(--d2l-color-mica);
+				border-right: 1px dashed var(--d2l-color-mica);
 			}
 
 			:host([is-rtl][scrollbar-right][show-actions]) .wrapper,
@@ -89,7 +89,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 
 			.action {
 				display: inline;
-				top: 10px;
+				top: 4px;
 			}
 
 			.sticky {
@@ -139,8 +139,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			}
 		</style>
 		<d2l-sticky-element class="sticky" disabled="[[_stickyIsDisabled]]">
-			<d2l-table-circle-button class="left action" icon="tier1:chevron-left" on-tap="handleTapLeft" tabindex="-1" aria-hidden="true" type="button"></d2l-table-circle-button>
-			<d2l-table-circle-button class="right action" icon="tier1:chevron-right" on-tap="handleTapRight" tabindex="-1" aria-hidden="true" type="button"></d2l-table-circle-button>
+			<d2l-table-circle-button class="left action" icon="tier1:chevron-left" on-tap="handleTapLeft" aria-hidden="true" type="button"></d2l-table-circle-button>
+			<d2l-table-circle-button class="right action" icon="tier1:chevron-right" on-tap="handleTapRight" aria-hidden="true" type="button"></d2l-table-circle-button>
 		</d2l-sticky-element>
 		<div id="wrapper" class="wrapper">
 			<div class="inner-wrapper"><slot></slot></div>

--- a/d2l-table-circle-button.js
+++ b/d2l-table-circle-button.js
@@ -24,9 +24,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-circle-button">
 				border: 0;
 			}
 			button.d2l-table-circle-button {
-				background-color: var(--d2l-scroll-wrapper-background-color);
-				border: 1px solid var(--d2l-scroll-wrapper-border-color);
+				background-color: var(--d2l-color-regolith);
+				border: 1px solid var(--d2l-color-mica);
 				border-radius: 50%;
+				box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.15);
 				box-sizing: content-box;
 				cursor: pointer;
 				display: inline-block;
@@ -41,12 +42,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-circle-button">
 			}
 			button.d2l-table-circle-button:hover,
 			button.d2l-table-circle-button:focus {
-				border-color: var(--d2l-color-celestine);
-				box-shadow: 0 2px 14px 1px rgba(0,0,0,0.06);
+				background-color: var(--d2l-color-sylvite);
 				outline-style: none;
 			}
-			button.d2l-table-circle-button > d2l-icon {
-				transition: color 0.3s ease;
+			button.d2l-table-circle-button:focus {
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine), 0 2px 12px 0 rgba(0, 0, 0, 0.15);
 			}
 		</style>
 		<button class="d2l-table-circle-button" type="button">

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -124,10 +124,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-wrapper">
 				--d2l-table-header-background-color: var(--d2l-color-regolith);
 				--d2l-table-border-overflow: dashed 1px var(--d2l-color-mica);
 			}
-			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
-				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
-			}
 		</style>
 		<d2l-scroll-wrapper show-actions is-sticky$="[[stickyHeaders]]">
 			<slot id="slot"></slot>

--- a/d2l-table.js
+++ b/d2l-table.js
@@ -132,10 +132,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table">
 			:host([hidden]) {
 				display: none;
 			}
-			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
-				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
-			}
 			.d2l-table-inner {
 				background-color: transparent;
 				border-collapse: separate!important;

--- a/demo/d2l-scroll-wrapper.html
+++ b/demo/d2l-scroll-wrapper.html
@@ -23,9 +23,6 @@ $_documentContainer.innerHTML = `<custom-style>
 		<style is="custom-style" include="d2l-typography">
 			html {
 				font-size: 20px;
-				--d2l-scroll-wrapper-background-color: red;
-				--d2l-scroll-wrapper-border-color: black;
-				--d2l-scroll-wrapper-overflow-border-color: purple;
 			}
 		</style>
 		</custom-style>`;
@@ -38,14 +35,14 @@ const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="d2l-demo-fixture">
 			<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" show-actions>
 				 <div style="width: 350px; height: 100px">
-					I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
+					I have action buttons that scroll this body. I will have dashed lines that appear when I reach either end.
 				 </div>
 			</d2l-scroll-wrapper>
 
 			<div dir="rtl">
 				<d2l-scroll-wrapper id="scroll-wrapper" style="width: 300px" show-actions>
 					 <div style="width: 350px; height: 100px">
-						I have red action buttons that scroll this body. I will have purple lines that appear when I reach either end.
+						I have action buttons that scroll this body. I will have dashed lines that appear when I reach either end.
 					 </div>
 				</d2l-scroll-wrapper>
 			</div>

--- a/demo/responsive.html
+++ b/demo/responsive.html
@@ -33,6 +33,10 @@ $_documentContainer.innerHTML = `<custom-style>
 				  font-size: 20px;
 				}
 
+				body {
+					margin: 20px;
+				}
+
 				.fixed-mobile-width {
 					max-width: 375px;
 					width: 100%;


### PR DESCRIPTION
These changes align the look of the buttons with design's original intent and have been tweaked by Jeff.

Changes:
- Horizontal offset is `10px` instead of `15px` which better matches the design and makes it look less “off centre”
- Vertical offset is `4px` instead of `10px` which centres it within the first row when used in a table
- Background colour is regolith instead of sylvite
- Border colour is mica instead of galena
- Box-shadow is the same as dropdowns (`0 2px 12px 0 rgba(0, 0, 0 0.15)`)

Before:
![Screen Shot 2021-03-19 at 5 04 13 PM](https://user-images.githubusercontent.com/5491151/112485830-b5638e00-8d51-11eb-97ef-f7610ef431fc.png)

After:
![Screen Shot 2021-03-24 at 4 37 38 PM](https://user-images.githubusercontent.com/5491151/112485862-bb596f00-8d51-11eb-95ab-d114acff57ef.png)

All the variables around this are gone as well -- I'll be cleaning up the places using this afterwards.