### PR TITLE
fix: reverting changes to z-index

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -277,7 +277,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: 0;
-				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tr[header] th,
@@ -343,7 +342,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				top: -5px;
 				border-left: none;
 				border-top: none;
-				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
@@ -364,7 +362,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: -5px;
-				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] th,
@@ -373,7 +370,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 				position: -webkit-sticky;
 				position: sticky;
 				top: -3.5px;
-				z-index: 3;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]) td,
@@ -424,7 +420,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] th[sticky],
 			d2l-table-wrapper[type="light"][sticky-headers] tr[header] td[sticky],
 			d2l-table-wrapper[type="light"][sticky-headers] thead > tr > th[sticky] {
-				z-index: 4; /* one higher so other header cells go under it */
+				z-index: 3;
 				left: 0;
 			}
 


### PR DESCRIPTION
This reverts the changes made [in this PR](https://github.com/BrightspaceUI/table/pull/220) and then the follow-up regression fix [in this PR](https://github.com/BrightspaceUI/table/pull/227). Cert fix for the April release against table version `2.4.x` will follow.

When `position: sticky` is applied to an element, anything that's positioned _relatively_ will go on top of it -- like our new numeric inputs (the source of #220) or our context-menus (an existing unreported bug).

![Screen Shot 2021-03-26 at 11 34 36 AM](https://user-images.githubusercontent.com/5491151/112655925-45273c00-8e27-11eb-99d1-d9c59e101171.png)

The solution to this (as done in #220) is to put a positive `z-index` on the sticky element. But that causes another issue as elements _inside_ the sticky element who wish to appear overtop of other things cannot escape. Such is the case with context-menus inside the sticky headers:

![Screen Shot 2021-03-26 at 11 37 37 AM](https://user-images.githubusercontent.com/5491151/112656359-b5ce5880-8e27-11eb-9876-b895ae2854ee.png)

The only solution to this new issue would be for the cells to have decreasing `z-index`es. So in this example, the first cell might have a `z-index` or 10, then the next one 9, 8 and so on. Obviously we'd need to apply this via JavaScript dynamically as tables can have any number of columns. But that would just solve this scenario -- what if the context-menu decided to open to the left instead of the right, or with RTL things would need to be reversed. Or if it was something else entirely. It's not a general solution.

So without a general solution to this right now, I'm left with reverting the `z-index` change (which I think is a good and [generally accepted fix](https://hackernoon.com/css-underdog-rule-position-sticky-0z2t3y7r) to the relative position issue) and going back to needing to override the relative positioning of our numeric inputs -- which I'll do in [a PR into core](https://github.com/BrightspaceUI/core/pull/1238) and [the LMS](https://github.com/Brightspace/lms/pull/8475). Unless folks have other ideas?

Just making things that wanted relative positioning static of course also isn't a general solution... if these text inputs used the new percent behaviour it wouldn't work, and of course our menus rely on relative positioning to work. So I'd still like to explore  other solutions to this when table gets converted to Lit.