### PR TITLE
feat: Hide d2l-scroll-wrapper visuals when printing webpages

### DIFF
--- a/d2l-scroll-wrapper.js
+++ b/d2l-scroll-wrapper.js
@@ -133,6 +133,16 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-scroll-wrapper">
 			:host([show-actions][scrollbar-left]) .left.action {
 				display: none;
 			}
+
+			@media print {
+				/* Hide wrapper visuals from print view */
+				:host .sticky {
+					display: none !important;
+				}
+				:host .wrapper {
+					border: none !important;
+				}
+			}
 		</style>
 		<d2l-sticky-element class="sticky" disabled="[[_stickyIsDisabled]]">
 			<d2l-table-circle-button class="left action" icon="tier1:chevron-left" on-tap="handleTapLeft" aria-hidden="true" type="button"></d2l-table-circle-button>


### PR DESCRIPTION
Motivated by rubric printing, where scroll wrapper borders/controls were carrying over from the browser view to the printed page view, even though no scrolling was necessary (or possible) on a printed page.

Related tickets: [US125790](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F508479614416) [US125179](https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F502202898352)