### PR TITLE
fix: removing RTL-only padding

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -260,11 +260,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 
 			/* sticky-headers */
 
-			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] table,
-			[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] table {
-				padding-left: 20px;
-			}
-
 			d2l-table-wrapper[type="default"][sticky-headers] tr,
 			d2l-table-wrapper[type="light"][sticky-headers] tr {
 				background-color: inherit;


### PR DESCRIPTION
I can't for the life of me figure out why this was needed -- it's putting `20px` of left padding on tables but only in RTL. The only outcome I can see is that tables in RTL end up being able to fit `20px` less stuff, which seems weird and wrong.

This was introduced with the initial sticky-headers stuff, so there's no history of it being added to fix something -- all I can think of is it was left in accidentally.

I'd like to remove it at this point so that when I exclude it from the Lit version it doesn't cause all the sticky+RTL visual diffs to be off.