### PR TITLE
fix: light tables don't need offsets for rounded corners

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -287,11 +287,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table-wrapper[type="default"][sticky-headers] td[sticky].d2l-table-cell-first,
 			d2l-table-wrapper[type="default"][sticky-headers] th[sticky].d2l-table-cell-first,
 			d2l-table-wrapper[type="default"][sticky-headers] td[sticky]:first-child,
-			d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child,
-			d2l-table-wrapper[type="light"][sticky-headers] td[sticky].d2l-table-cell-first,
-			d2l-table-wrapper[type="light"][sticky-headers] th[sticky].d2l-table-cell-first,
-			d2l-table-wrapper[type="light"][sticky-headers] td[sticky]:first-child,
-			d2l-table-wrapper[type="light"][sticky-headers] th[sticky]:first-child {
+			d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child {
 				left: -5px;
 			}
 
@@ -305,11 +301,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] td[sticky].d2l-table-cell-first,
 			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky].d2l-table-cell-first,
 			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] td[sticky]:first-child,
-			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child,
-			[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] td[sticky].d2l-table-cell-first,
-			[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] th[sticky].d2l-table-cell-first,
-			[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] td[sticky]:first-child,
-			[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] th[sticky]:first-child {
+			[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child {
 				right: -5px;
 			}
 
@@ -364,7 +356,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 			d2l-table-wrapper[type="light"][sticky-headers] thead tr th {
 				position: -webkit-sticky;
 				position: sticky;
-				top: -3.5px;
 			}
 
 			d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]) td,

--- a/d2l-table-wrapper.js
+++ b/d2l-table-wrapper.js
@@ -102,7 +102,6 @@ Custom property | Description | Default
   then delete this comment!
 */
 import '@polymer/polymer/polymer-legacy.js';
-
 import 'd2l-colors/d2l-colors.js';
 import 'fastdom/fastdom.js';
 import './d2l-scroll-wrapper.js';
@@ -257,8 +256,9 @@ Polymer({
 			}
 
 			var ths = this.querySelectorAll('.d2l-table tr[header]:not(:first-child) th, .d2l-table thead tr:not(:first-child) th');
+			const offset = this.type === 'default' ? -3 : 1; // default: -5px top + 2px border, light: 0 top + 1px border
 			for (var i = 0; i < ths.length; i++) {
-				ths[i].style.top = topHeader.clientHeight - 3 + 'px';
+				ths[i].style.top = topHeader.clientHeight + offset + 'px';
 			}
 		}.bind(this));
 	},


### PR DESCRIPTION
One more small set of fixes to make the visual diff tests for the Lit conversion less jarring.

These negative top/left offsets for sticky header tables exist so that when you scroll, the borders don't show through the "default" style table's rounded corners. But light tables don't have rounded corners, so applying the offsets isn't needed.

Second, for multi-row sticky headers there's logic that goes through and sets a top offset equal to the height of the first row. That calculation only ever worked for the "default" style which has a `-5px` offset and `2px` border (hence it had `3px` subtracted from it). For "light" tables, this needs to be `+1px` to compensate for the border only.

Before change (note the misaligned border and the missing border between the 1st & 2nd header row):
![Screen Shot 2021-05-05 at 2 20 41 PM](https://user-images.githubusercontent.com/5491151/117193543-fae39400-adb0-11eb-97fb-35e52f3ff576.png)

After change:
![Screen Shot 2021-05-05 at 2 24 47 PM](https://user-images.githubusercontent.com/5491151/117193595-0d5dcd80-adb1-11eb-842c-168c24df597a.png)
