### PR TITLE
fix: including Lit table styles in the dom-module

### DIFF
--- a/d2l-table-style.js
+++ b/d2l-table-style.js
@@ -2,18 +2,12 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/polymer/polymer-legacy.js';
 import { tableStyles } from '@brightspace-ui/core/components/table/table-wrapper.js';
 
-if (document.getElementById('d2l-table-style-shared') === null) {
-	const style = document.createElement('style');
-	style.id = 'd2l-table-style-shared';
-	style.appendChild(document.createTextNode(tableStyles.cssText));
-	document.head.appendChild(style);
-}
-
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-table-style">
 	<template>
 		<style>
+			${tableStyles.cssText}
 			d2l-thead {
 				display: table-header-group;
 			}


### PR DESCRIPTION
I missed one use case: using `<d2l-table-wrapper>` from inside a Polymer element. In that scenario, the styles were getting added to the root document but couldn't pierce the wrapper element's shadow root so weren't getting applied.

This change just moves them into the style `dom-module` just like the older d2l-table/d2l-tr/etc. styles.

The unfortunate side-effect of all this is that Polymer elements will need to continue to use the Polymer version of d2l-table, and Lit ones will need to use the Lit version -- no mixing and matching. So that kind of goes against how web components work... but I'm justifying it in my mind by thinking of these more as shared styles than a web component. In Polymer the way you share styles is these `dom-module`s and in Lit it's importing style literals into your component. 🤷 