### PR TITLE
feat: remove use of `@brightspace-ui/resize-aware`

### DIFF
--- a/d2l-tspan.js
+++ b/d2l-tspan.js
@@ -132,7 +132,7 @@ Polymer({
 		}
 	},
 	ready: function() {
-		this._resizeObserver = new ResizeObserver(()=> this._onSizeChanged())
+		this._resizeObserver = new ResizeObserver(()=> this._onSizeChanged());
 	},
 	attached: function() {
 		const resizeDetector = this.$['resize-detector'];

--- a/d2l-tspan.js
+++ b/d2l-tspan.js
@@ -3,7 +3,8 @@ import './d2l-table-observer-behavior.js';
 import './d2l-td.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
-import '@brightspace-ui/resize-aware/d2l-resize-aware.js';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-tspan">
@@ -67,16 +68,16 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-tspan">
 				border-bottom: var(--d2l-table-light-border);
 			}
 
-			d2l-resize-aware {
+			#resize-detector {
 				display: block;
 				width: 100%;
 			}
 		</style>
 		<d2l-td id="cell">
 			<div id="float" class="d2l-tspan-float">
-				<d2l-resize-aware id="resize-detector">
+				<div id="resize-detector">
 					<slot></slot>
-				</d2l-resize-aware>
+				</div>
 			</div>
 		</d2l-td>
 	</template>
@@ -131,10 +132,11 @@ Polymer({
 		}
 	},
 	ready: function() {
-		this._onSizeChanged = this._onSizeChanged.bind(this);
+		this._resizeObserver = new ResizeObserver(()=> this._onSizeChanged())
 	},
 	attached: function() {
-		this.$['resize-detector'].addEventListener('d2l-resize-aware-resized', this._onSizeChanged);
+		const resizeDetector = this.$['resize-detector'];
+		this._resizeObserver.observe(resizeDetector);
 		var slot = dom(this.root).querySelector('#float');
 		if (this.focusedStyling) {
 			slot.addEventListener('focusout', this._boundFocusOutHandler);
@@ -143,7 +145,10 @@ Polymer({
 		this.root.host.style.height = this.$.float.offsetHeight + 'px';
 	},
 	detached: function() {
-		this.$['resize-detector'].removeEventListener('d2l-resize-aware-resized', this._onSizeChanged);
+		if (this._resizeObserver) {
+			this._resizeObserver.disconnect();
+			this._resizeObserver = null;
+		}
 		var slot = dom(this.root).querySelector('#float');
 		if (this.focusedStyling) {
 			slot.removeEventListener('focusout', this._boundFocusOutHandler);

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html demo/**/*.html",
     "lint:wc": "polymer lint",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "start": "wds --node-resolve --watch --open demo/"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.14.2",
     "@babel/eslint-parser": "^7",
+    "@web/dev-server": "^0.2",
     "@webcomponents/webcomponentsjs": "^2",
     "eslint": "^7",
     "eslint-config-brightspace": "^0.14",
@@ -50,8 +52,8 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "@brightspace-ui/resize-aware": "^1",
     "@polymer/polymer": "^3",
-    "fastdom": "^1.0.8"
+    "fastdom": "^1.0.8",
+    "resize-observer-polyfill": "^1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
   },
   "name": "@brightspace-ui/table",
   "scripts": {
-    "lint": "npm run lint:wc && npm run lint:js",
+    "lint": "npm run lint:js",
     "lint:js": "eslint . --ext .js,.html demo/**/*.html",
-    "lint:wc": "polymer lint",
     "test": "npm run lint",
     "start": "wds --node-resolve --watch --open demo/"
   },
@@ -27,8 +26,7 @@
     "eslint": "^7",
     "eslint-config-brightspace": "^0.14",
     "eslint-plugin-html": "^6",
-    "eslint-plugin-sort-class-members": "^1.11.0",
-    "polymer-cli": "^1"
+    "eslint-plugin-sort-class-members": "^1.11.0"
   },
   "version": "3.2.0",
   "main": "d2l-table.js",

--- a/polymer.json
+++ b/polymer.json
@@ -1,8 +1,0 @@
-{
-  "npm": true,
-  "lint": {
-    "rules": [
-      "polymer-3"
-    ]
-  }
-}


### PR DESCRIPTION
This switches to use the native `ResizeObserver` (with polyfill for older browsers) over using the `@brightspace-ui/resize-aware` stuff. Tested using demo pages. Updated to run demos wtih `@web/dev-server` since `polymer` didn't like optional chaining stuff.